### PR TITLE
Changing key values - CoreSettings

### DIFF
--- a/AzzyBot/Settings/appsettings.json
+++ b/AzzyBot/Settings/appsettings.json
@@ -13,8 +13,8 @@
         "Updater": {
             "DisplayChangelog": true,
             "DisplayInstructions": true,
-            "UpdateCheckInterval": 1,
-            "UpdateMessageChannelId": 0
+            "CheckInterval": 1,
+            "MessageChannelId": 0
         }
     },
     "AzuraCast": {


### PR DESCRIPTION
Hello !
I tried to start the bot with docker this morning, but this doesn't work.
I have this error: 
```
2024-04-26 12:18:34 fail: AzzyBot.AzzyBot[4] AdminRoleId has to be filled out!
2024-04-26 12:18:34 fail: AzzyBot.AzzyBot[4] UpdaterCheckInterval has to be filled out!
2024-04-26 12:18:34 fail: AzzyBot.AzzyBot[4] Core settings aren't loaded
```

I looked in the code (https://github.com/Sella-GH/AzzyBot/blob/main/AzzyBot/Modules/Core/Settings/CoreSettings.cs)
and indeed the configuration values have been changed, without being changed in the settings file.

I hope you find it useful!
Have a nice day!