### PR TITLE
Add check if Icecast streaming is enabled and adjust embed response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixes
 - Checking if a song was requested already now works exactly as wanted
 - Options validation now works correctly and doesn't throw exceptions anymore
+- `music nowplaying` works again when you stream over icecast instead of the integrated AzuraCast stream feature
 
 ### Development
 - Moved some stuff out of dockerfiles to github workflow

--- a/src/AzzyBot.Bot/Utilities/EmbedBuilder.cs
+++ b/src/AzzyBot.Bot/Utilities/EmbedBuilder.cs
@@ -186,6 +186,7 @@ public static class EmbedBuilder
         if (isLive)
         {
             message = $"Currently served *live* by the one and only **{data.Live.StreamerName}**";
+            fields.Add("Streaming live since", new($"<t:{Converter.ConvertFromUnixTime(Convert.ToInt64(data.Live.BroadcastStart, CultureInfo.InvariantCulture))}>"));
         }
         else if (isIcecastLive)
         {
@@ -205,9 +206,6 @@ public static class EmbedBuilder
 
             fields.Add("Duration", new($"{progressBar} `[{songElapsed} / {songDuration}]`"));
         }
-
-        if (isLive || isIcecastLive)
-            fields.Add("Streaming live since", new($"<t:{Converter.ConvertFromUnixTime(Convert.ToInt64(data.Live.BroadcastStart, CultureInfo.InvariantCulture))}>"));
 
         return CreateBasicEmbed(title, message, DiscordColor.Aquamarine, new(thumbnailUrl), fields: fields);
     }


### PR DESCRIPTION
## Summary
Add check if Icecast streaming is enabled and adjust embed response

## Specific changes
Add a check in the embed creation if the `duration` field is 0 which can possibly be because you stream over Icecast. Then the `live` field is false and Azzy can't detect streaming activity.

## Resolves Issues?
Fixes #305 

## Additional information
May can change other behavior, monitor bug reports.