### PR TITLE
Potential fix for code scanning alert no. 777: Constant condition

### DIFF
--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -449,22 +449,15 @@ public sealed class ConfigCommands
             {
                 await _dbActions.UpdateAzuraCastStationPreferencesAsync(context.Guild.Id, station, adminGroup?.Id, djGroup?.Id, uploadChannel?.Id, null, null, requestsChannel?.Id, uploadPath, showPlaylistInEmbed);
 
-                ulong[] channels = [];
-                if (requestsChannel is not null && uploadChannel is null)
-                {
-                    channels = [requestsChannel.Id];
-                }
-                else if (uploadChannel is not null && requestsChannel is null)
-                {
-                    channels = [uploadChannel.Id];
-                }
-                else
-                {
-                    channels = [requestsChannel.Id, uploadChannel.Id];
-                }
+                List<ulong> channels = new(2);
+                if (requestsChannel is not null)
+                    channels.Add(requestsChannel.Id);
 
-                if (channels.Length is not 0)
-                    await _botService.CheckPermissionsAsync(context.Guild, channels);
+                if (uploadChannel is not null)
+                    channels.Add(uploadChannel.Id);
+
+                if (channels.Count is not 0)
+                    await _botService.CheckPermissionsAsync(context.Guild, [.. channels]);
             }
 
             if (stationId.HasValue || !string.IsNullOrWhiteSpace(apiKey))


### PR DESCRIPTION
Potential fix for [https://github.com/Sella-GH/AzzyBot/security/code-scanning/777](https://github.com/Sella-GH/AzzyBot/security/code-scanning/777)

To fix the issue, the superfluous condition should be replaced with an unconditional `else` block. This would improve readability and clarify that this is the third and final case (both not null) after previous exclusive cases.  

- Specifically, replace `else if (requestsChannel is not null && uploadChannel is not null)`  
  with simply `else`.
- This edit should be in file `src/AzzyBot.Bot/Commands/ConfigCommands.cs`, lines 461-464 (providing enough context for clarity).

No additional methods/imports/definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
