### PR TITLE
Handle Cloudflare origin-unreachable errors and improve status checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ﻿## Unreleased
 ### Improvements
 - Migrated from [TagLibSharp](https://github.com/mono/taglib-sharp) to [TagLibSharp2](https://github.com/decriptor/TagLibSharp2)
+- Status codes 502, 503, 504 and 520 - 526 are now handled as offline status for AzuraCast instances
 
 ## 2.9.1 - 2026-03-01
 ### Fixes

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -214,10 +214,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
             }
 
             int statusCode = (int)status;
-            if (status is HttpStatusCode.BadGateway
-                         or HttpStatusCode.ServiceUnavailable
-                         or HttpStatusCode.GatewayTimeout ||
-                    (statusCode >= 520 && statusCode <= 526))
+            if (statusCode is 502 or 503 or 504 or (>= 520 and <= 526))
             {
                 throw new HttpRequestException($"Server unreachable ({statusCode} {status}).");
             }

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -215,9 +215,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
 
             int statusCode = (int)status;
             if (statusCode is 502 or 503 or 504 or (>= 520 and <= 526))
-            {
                 throw new HttpRequestException($"Server unreachable ({statusCode} {status}).");
-            }
 
             return (status is not HttpStatusCode.Forbidden) ? responseContent : null;
         }

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
@@ -216,8 +216,8 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
             int statusCode = (int)status;
             if (status is HttpStatusCode.BadGateway
                          or HttpStatusCode.ServiceUnavailable
-                         or HttpStatusCode.GatewayTimeout
-                || (statusCode >= 520 && statusCode <= 526))
+                         or HttpStatusCode.GatewayTimeout ||
+                    (statusCode >= 520 && statusCode <= 526))
             {
                 throw new HttpRequestException($"Server unreachable ({statusCode} {status}).");
             }

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -215,7 +215,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
 
             int statusCode = (int)status;
             if (statusCode is 502 or 503 or 504 or (>= 520 and <= 526))
-                throw new HttpRequestException($"Server unreachable ({statusCode} {status}).");
+                throw new HttpRequestException($"Server is unreachable ({statusCode}).");
 
             return (status is not HttpStatusCode.Forbidden) ? responseContent : null;
         }

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -213,6 +213,15 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
                 responseContent = await response.Content.ReadAsStringAsync();
             }
 
+            int statusCode = (int)status;
+            if (status is HttpStatusCode.BadGateway
+                         or HttpStatusCode.ServiceUnavailable
+                         or HttpStatusCode.GatewayTimeout
+                || (statusCode >= 520 && statusCode <= 526))
+            {
+                throw new HttpRequestException($"Server unreachable ({statusCode} {status}).");
+            }
+
             return (status is not HttpStatusCode.Forbidden) ? responseContent : null;
         }
         catch (InvalidOperationException)


### PR DESCRIPTION
## Summary
This pull request enhances how AzuraCast instance availability is detected by expanding the set of HTTP status codes considered as indicating an offline state.

## Specific changes
* Updated `WebRequestService` to treat HTTP status codes 502, 503, 504, and 520–526 as "offline" for AzuraCast instances, throwing an exception to indicate the server is unreachable.

## Resolves Issues?
> Fixes #531 
