### PR TITLE
Fix AzuraCast File Data fetching

### DIFF
--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
@@ -143,7 +143,7 @@ public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocom
             }
             else
             {
-                IEnumerable<AzuraFilesDetailedRecord>? filesOnline = await _azuraCast.GetFilesOnlineAsync(baseUrl, apiKey, stationId);
+                IEnumerable<AzuraFilesDetailedRecord>? filesOnline = await _azuraCast.GetFilesOnlineDetailedAsync(baseUrl, apiKey, stationId);
                 if (filesOnline is null)
                 {
                     await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station ({stationId}).\n{AzuraCastApiService.AzuraCastPermissionsWiki}");

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -673,7 +673,7 @@ public sealed class AzuraCastCommands
                 return;
             }
 
-            IEnumerable<AzuraFilesRecord>? songs = await _azuraCast.GetFilesOnlineAsync(baseUrl, apiKey, station);
+            IEnumerable<AzuraFilesRecord>? songs = await _azuraCast.GetFilesOnlineBasicAsync(baseUrl, apiKey, station);
             if (songs is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -354,11 +354,17 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, Dis
 
         string file = GetLocalFile(guildId, azuraCastId, databaseId, stationId);
         if (string.IsNullOrEmpty(file))
+        {
+            _logger.LocalFileNotFound(stationId, databaseId, azuraCastId, guildId);
             return [];
+        }
 
         string content = await FileOperations.GetFileContentAsync(file);
         if (string.IsNullOrEmpty(content))
+        {
+            _logger.LocalFileContentNotFound(stationId, databaseId, azuraCastId, guildId);
             return [];
+        }
 
         try
         {

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -263,6 +263,13 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, Dis
         return files.FirstOrDefault(f => f.Contains(fileName, StringComparison.OrdinalIgnoreCase)) ?? string.Empty;
     }
 
+    private Task<IEnumerable<AzuraFilesDetailedRecord>?> GetOnlineFilesAsync(Uri baseUrl, string apiKey, int stationId)
+    {
+        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Files}";
+
+        return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraFilesDetailedRecord, CreateHeader(apiKey));
+    }
+
     private async Task PostToApiAsync(Uri baseUrl, string endpoint, string? content = null, Dictionary<string, string>? headers = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
@@ -377,14 +384,24 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, Dis
         }
     }
 
-    public Task<IEnumerable<AzuraFilesDetailedRecord>?> GetFilesOnlineAsync(Uri baseUrl, string apiKey, int stationId)
+    public async Task<IEnumerable<AzuraFilesRecord>?> GetFilesOnlineBasicAsync(Uri baseUrl, string apiKey, int stationId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stationId);
 
-        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Files}";
+        IEnumerable<AzuraFilesDetailedRecord>? detailed = await GetOnlineFilesAsync(baseUrl, apiKey, stationId);
+        if (detailed is null)
+            return null;
 
-        return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraFilesDetailedRecord, CreateHeader(apiKey));
+        return detailed.Cast<AzuraFilesRecord>();
+    }
+
+    public Task<IEnumerable<AzuraFilesDetailedRecord>?> GetFilesOnlineDetailedAsync(Uri baseUrl, string apiKey, int stationId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stationId);
+
+        return GetOnlineFilesAsync(baseUrl, apiKey, stationId);
     }
 
     public async Task<AzuraHardwareStatsRecord?> GetHardwareStatsAsync(Uri baseUrl, string apiKey)
@@ -489,7 +506,7 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, Dis
         ArgumentNullException.ThrowIfNull(station);
 
         IEnumerable<AzuraFilesRecord>? songs = (online)
-            ? await GetFilesOnlineAsync(baseUrl, apiKey, station.StationId)
+            ? await GetFilesOnlineBasicAsync(baseUrl, apiKey, station.StationId)
             : await GetFilesLocalAsync(station.AzuraCast.GuildId, station.AzuraCastId, station.Id, station.StationId);
 
         if (songs is null)

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -263,13 +263,6 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, Dis
         return files.FirstOrDefault(f => f.Contains(fileName, StringComparison.OrdinalIgnoreCase)) ?? string.Empty;
     }
 
-    private Task<IEnumerable<AzuraFilesDetailedRecord>?> GetOnlineFilesAsync(Uri baseUrl, string apiKey, int stationId)
-    {
-        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Files}";
-
-        return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraFilesDetailedRecord, CreateHeader(apiKey));
-    }
-
     private async Task PostToApiAsync(Uri baseUrl, string endpoint, string? content = null, Dictionary<string, string>? headers = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
@@ -384,16 +377,14 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, Dis
         }
     }
 
-    public async Task<IEnumerable<AzuraFilesRecord>?> GetFilesOnlineBasicAsync(Uri baseUrl, string apiKey, int stationId)
+    public Task<IEnumerable<AzuraFilesRecord>?> GetFilesOnlineBasicAsync(Uri baseUrl, string apiKey, int stationId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stationId);
 
-        IEnumerable<AzuraFilesDetailedRecord>? detailed = await GetOnlineFilesAsync(baseUrl, apiKey, stationId);
-        if (detailed is null)
-            return null;
+        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Files}";
 
-        return detailed.Cast<AzuraFilesRecord>();
+        return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraFilesRecord, CreateHeader(apiKey));
     }
 
     public Task<IEnumerable<AzuraFilesDetailedRecord>?> GetFilesOnlineDetailedAsync(Uri baseUrl, string apiKey, int stationId)
@@ -401,7 +392,9 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, Dis
         ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stationId);
 
-        return GetOnlineFilesAsync(baseUrl, apiKey, stationId);
+        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Files}";
+
+        return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraFilesDetailedRecord, CreateHeader(apiKey));
     }
 
     public async Task<AzuraHardwareStatsRecord?> GetHardwareStatsAsync(Uri baseUrl, string apiKey)

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
@@ -44,7 +44,7 @@ public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, A
             return;
         }
 
-        IEnumerable<AzuraFilesRecord>? onlineFiles = await _azuraCast.GetFilesOnlineAsync(baseUrl, apiKey, station.StationId);
+        IEnumerable<AzuraFilesRecord>? onlineFiles = await _azuraCast.GetFilesOnlineBasicAsync(baseUrl, apiKey, station.StationId);
         if (onlineFiles is null)
         {
             await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station *{azuraStation.Name}* (ID: {station.StationId}).\n{AzuraCastApiService.AzuraCastPermissionsWiki}");

--- a/src/AzzyBot.Core/Logging/LoggerActions.cs
+++ b/src/AzzyBot.Core/Logging/LoggerActions.cs
@@ -186,6 +186,12 @@ public static partial class LoggerActions
     [LoggerMessage(251, LogLevel.Warning, "Unable to notify admins or owner of guild {guildName} ({guildId}) about being unused")]
     public static partial void UnableToNotifyUnusedGuildUnused(this ILogger logger, string guildName, ulong guildId);
 
+    [LoggerMessage(260, LogLevel.Warning, "Could not find local file for station {station} (db: {dId}) in instance {instance} in guild {guild}")]
+    public static partial void LocalFileNotFound(this ILogger logger, int station, int dId, int instance, int guild);
+
+    [LoggerMessage(261, LogLevel.Warning, "Could not fetch local file content for station {station} (db: {dId}) in instance {instance} in guild {guild}")]
+    public static partial void LocalFileContentNotFound(this ILogger logger, int station, int dId, int instance, int guild);
+
     [LoggerMessage(290, LogLevel.Warning, "Latest online version of the bot is empty")]
     public static partial void OnlineVersionEmpty(this ILogger logger);
 


### PR DESCRIPTION
This pull request refactors how AzuraCast file data is fetched and improves error logging for local file operations. The main changes involve splitting the online file retrieval methods into "basic" and "detailed" variants, updating all usages to call the appropriate method, and adding new logger messages to help diagnose local file issues.

**Refactoring AzuraCast file retrieval:**

* Split the `GetFilesOnlineAsync` method into two: `GetFilesOnlineBasicAsync` (returns `AzuraFilesRecord`) and `GetFilesOnlineDetailedAsync` (returns `AzuraFilesDetailedRecord`). All previous usages of `GetFilesOnlineAsync` have been updated to use `GetFilesOnlineBasicAsync` or `GetFilesOnlineDetailedAsync` as appropriate. [[1]](diffhunk://#diff-295528a42b2ac5b52a7ea1e0101e1710afd853bdf3c14ef8cddcb0a23aad5d19L374-R390) [[2]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL676-R676) [[3]](diffhunk://#diff-0eb8fcc68e9b7062acefdd27eac12e66b3873c901044b2bfa3da7f5cf7b34e39L146-R146) [[4]](diffhunk://#diff-295528a42b2ac5b52a7ea1e0101e1710afd853bdf3c14ef8cddcb0a23aad5d19L486-R502) [[5]](diffhunk://#diff-72d592a28730ea08a65de68ce1f1647817dbb5d63fd330d314916d6b0761a56fL47-R47)
* The submodule `extern/Lavalink4NET` was removed because of mistakes.

**Improved logging for local files:**

* Added new logger actions: `LocalFileNotFound` and `LocalFileContentNotFound` to provide clearer warnings when local AzuraCast files or their contents cannot be found. These are now called in `GetFilesLocalAsync` when appropriate. [[1]](diffhunk://#diff-1d5e7b307d65317442cab9b735b6558b2215932ae6d32b7e7b5bd46859089aa3R189-R194) [[2]](diffhunk://#diff-295528a42b2ac5b52a7ea1e0101e1710afd853bdf3c14ef8cddcb0a23aad5d19R357-R367)