### PR TITLE
Add missing library to Dockerfiles and upgrade to Ubuntu 26.04

### DIFF
--- a/AzzyBot.slnx
+++ b/AzzyBot.slnx
@@ -8,7 +8,13 @@
     <Platform Name="ARM64" />
     <Platform Name="x64" />
   </Configurations>
-  <Folder Name="/actions/">
+  <Folder Name="/docker/">
+    <File Path="dev.alpine.Dockerfile" />
+    <File Path="dev.Dockerfile" />
+    <File Path="release.alpine.Dockerfile" />
+    <File Path="release.Dockerfile" />
+  </Folder>
+  <Folder Name="/github/">
     <File Path=".github/copilot-instructions.md" />
     <File Path=".github/dependabot.yml" />
     <File Path=".github/ISSUE_TEMPLATE/bug_report.yml" />

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -22,7 +22,12 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0-noble AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN apt update && apt upgrade -y && apt install -y --no-install-recommends iputils-ping libzstd-dev && apt autoremove --purge -y && apt clean -y && rm -rf /var/lib/apt/lists/*
+RUN apt update \
+  && apt upgrade -y \
+  && apt install -y --no-install-recommends iputils-ping libzstd-dev \
+  && apt autoremove --purge -y \
+  && apt clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Add environment variables
 ENV PATH="/usr/local/zstd:${PATH}" \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:labs
 
 # BUILD IMAGE
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
 USER root
 
 RUN apt update && apt upgrade -y && apt autoremove -y && apt clean -y
@@ -18,7 +18,7 @@ RUN dotnet restore ./src/AzzyBot.Bot/AzzyBot.Bot.csproj --configfile ./Nuget.con
   && dotnet publish ./src/AzzyBot.Bot/AzzyBot.Bot.csproj -c $CONFIG --no-build --no-restore --no-self-contained -o out --ucr
 
 # RUNNER IMAGE
-FROM mcr.microsoft.com/dotnet/runtime:10.0-noble AS runner
+FROM mcr.microsoft.com/dotnet/runtime:10.0-resolute AS runner
 USER root
 
 # Upgrade internal tools and packages first

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -4,7 +4,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
 USER root
 
-RUN apt update && apt upgrade -y && apt autoremove -y && apt clean -y
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get autoremove -y \
+  && apt-get clean -y
 
 WORKDIR /build
 COPY ./ ./
@@ -22,11 +25,11 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0-resolute AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN apt update \
-  && apt upgrade -y \
-  && apt install -y --no-install-recommends iputils-ping libzstd-dev \
-  && apt autoremove --purge -y \
-  && apt clean -y \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends iputils-ping libzstd-dev \
+  && apt-get autoremove --purge -y \
+  && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Add environment variables

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -27,7 +27,7 @@ USER root
 # Upgrade internal tools and packages first
 RUN apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends iputils-ping libzstd-dev \
+  && apt-get install -y --no-install-recommends iputils-ping libgssapi-krb5-2 libzstd-dev \
   && apt-get autoremove --purge -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*

--- a/dev.alpine.Dockerfile
+++ b/dev.alpine.Dockerfile
@@ -4,7 +4,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 USER root
 
-RUN apk update && apk upgrade && apk cache sync
+RUN apk update \
+  && apk upgrade \
+  && apk cache sync
 
 WORKDIR /build
 COPY ./ ./
@@ -24,7 +26,7 @@ USER root
 # Upgrade internal tools and packages first
 RUN apk update \
   && apk upgrade \
-  && apk add --no-cache icu-data-full icu-libs iputils-ping tzdata zstd-dev \
+  && apk add --no-cache icu-data-full icu-libs iputils-ping krb5-libs tzdata zstd-dev \
   && apk cache sync \
   && rm -rf /var/cache/apk/*
 

--- a/dev.alpine.Dockerfile
+++ b/dev.alpine.Dockerfile
@@ -22,7 +22,11 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN apk update && apk upgrade && apk add --no-cache icu-data-full icu-libs iputils-ping tzdata zstd-dev && apk cache sync && rm -rf /var/cache/apk/*
+RUN apk update \
+  && apk upgrade \
+  && apk add --no-cache icu-data-full icu-libs iputils-ping tzdata zstd-dev \
+  && apk cache sync \
+  && rm -rf /var/cache/apk/*
 
 # Add environment variables
 ENV PATH="/usr/local/zstd:${PATH}" \

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -22,7 +22,12 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0-noble AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN apt update && apt upgrade -y && apt install -y --no-install-recommends iputils-ping libzstd-dev && apt autoremove --purge -y && apt clean -y && rm -rf /var/lib/apt/lists/*
+RUN apt update \
+  && apt upgrade -y \
+  && apt install -y --no-install-recommends iputils-ping libzstd-dev \
+  && apt autoremove --purge -y \
+  && apt clean -y \
+  && rm -rf /var/lib/apt/lists/*
 
 # Add environment variables
 ENV PATH="/usr/local/zstd:${PATH}" \

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:labs
 
 # BUILD IMAGE
-FROM mcr.microsoft.com/dotnet/sdk:10.0-noble AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
 USER root
 
 RUN apt update && apt upgrade -y && apt autoremove -y && apt clean -y
@@ -18,7 +18,7 @@ RUN dotnet restore ./src/AzzyBot.Bot/AzzyBot.Bot.csproj --configfile ./Nuget.con
   && dotnet publish ./src/AzzyBot.Bot/AzzyBot.Bot.csproj -c $CONFIG --no-build --no-restore --no-self-contained -o out --ucr
 
 # RUNNER IMAGE
-FROM mcr.microsoft.com/dotnet/runtime:10.0-noble AS runner
+FROM mcr.microsoft.com/dotnet/runtime:10.0-resolute AS runner
 USER root
 
 # Upgrade internal tools and packages first

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -4,7 +4,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
 USER root
 
-RUN apt update && apt upgrade -y && apt autoremove -y && apt clean -y
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get autoremove -y \
+  && apt-get clean -y
 
 WORKDIR /build
 COPY ./ ./
@@ -22,11 +25,11 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0-resolute AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN apt update \
-  && apt upgrade -y \
-  && apt install -y --no-install-recommends iputils-ping libzstd-dev \
-  && apt autoremove --purge -y \
-  && apt clean -y \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends iputils-ping libzstd-dev \
+  && apt-get autoremove --purge -y \
+  && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Add environment variables

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -27,7 +27,7 @@ USER root
 # Upgrade internal tools and packages first
 RUN apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends iputils-ping libzstd-dev \
+  && apt-get install -y --no-install-recommends iputils-ping libgssapi-krb5-2 libzstd-dev \
   && apt-get autoremove --purge -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*

--- a/release.alpine.Dockerfile
+++ b/release.alpine.Dockerfile
@@ -4,7 +4,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
 USER root
 
-RUN apk update && apk upgrade && apk cache sync
+RUN apk update \
+  && apk upgrade \
+  && apk cache sync
 
 WORKDIR /build
 COPY ./ ./
@@ -24,7 +26,7 @@ USER root
 # Upgrade internal tools and packages first
 RUN apk update \
   && apk upgrade \
-  && apk add --no-cache icu-data-full icu-libs iputils-ping tzdata zstd-dev \
+  && apk add --no-cache icu-data-full icu-libs iputils-ping krb5-libs tzdata zstd-dev \
   && apk cache sync \
   && rm -rf /var/cache/apk/*
 

--- a/release.alpine.Dockerfile
+++ b/release.alpine.Dockerfile
@@ -22,7 +22,11 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0-alpine AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN apk update && apk upgrade && apk add --no-cache icu-data-full icu-libs iputils-ping tzdata zstd-dev && apk cache sync && rm -rf /var/cache/apk/*
+RUN apk update \
+  && apk upgrade \
+  && apk add --no-cache icu-data-full icu-libs iputils-ping tzdata zstd-dev \
+  && apk cache sync \
+  && rm -rf /var/cache/apk/*
 
 # Add environment variables
 ENV PATH="/usr/local/zstd:${PATH}" \


### PR DESCRIPTION
This pull request updates the Dockerfiles for both development and release builds (including Alpine variants) to use newer .NET 10.0-resolute base images, improves package installation commands for better reliability, and adds missing dependencies for Kerberos support. Additionally, it reorganizes the solution structure for better clarity.

**Dockerfile improvements and dependency updates:**

* Updated all Dockerfiles (`dev.Dockerfile`, `release.Dockerfile`, `dev.alpine.Dockerfile`, `release.alpine.Dockerfile`) to use the `10.0-resolute` (and `10.0-alpine`) .NET base images instead of `10.0-noble`, ensuring compatibility with the latest .NET releases. [[1]](diffhunk://#diff-3ed65642ec1610de6b0f162c77dc8499662ebeb7057d3f6c89108952d1cb33deL4-R10) [[2]](diffhunk://#diff-3ed65642ec1610de6b0f162c77dc8499662ebeb7057d3f6c89108952d1cb33deL21-R33) [[3]](diffhunk://#diff-f1bd05d0cabc71ca98e58fb9f5bb9f51d115733d359f9d289ebc0d158b0cb2a8L4-R10) [[4]](diffhunk://#diff-f1bd05d0cabc71ca98e58fb9f5bb9f51d115733d359f9d289ebc0d158b0cb2a8L21-R33) [[5]](diffhunk://#diff-434b08383a91d5e4883675176bbff7b4809a83f519bab6207710728a2c750ca8L7-R9) [[6]](diffhunk://#diff-434b08383a91d5e4883675176bbff7b4809a83f519bab6207710728a2c750ca8L25-R31) [[7]](diffhunk://#diff-58401038a90aa7cb4db244527416d6665ad0807fb5baf2751514aceeb7313c6fL7-R9) [[8]](diffhunk://#diff-58401038a90aa7cb4db244527416d6665ad0807fb5baf2751514aceeb7313c6fL25-R31)
* Changed package management commands from `apt` to `apt-get` (and improved `apk` usage in Alpine images) for more robust and predictable builds. [[1]](diffhunk://#diff-3ed65642ec1610de6b0f162c77dc8499662ebeb7057d3f6c89108952d1cb33deL4-R10) [[2]](diffhunk://#diff-3ed65642ec1610de6b0f162c77dc8499662ebeb7057d3f6c89108952d1cb33deL21-R33) [[3]](diffhunk://#diff-f1bd05d0cabc71ca98e58fb9f5bb9f51d115733d359f9d289ebc0d158b0cb2a8L4-R10) [[4]](diffhunk://#diff-f1bd05d0cabc71ca98e58fb9f5bb9f51d115733d359f9d289ebc0d158b0cb2a8L21-R33) [[5]](diffhunk://#diff-434b08383a91d5e4883675176bbff7b4809a83f519bab6207710728a2c750ca8L7-R9) [[6]](diffhunk://#diff-434b08383a91d5e4883675176bbff7b4809a83f519bab6207710728a2c750ca8L25-R31) [[7]](diffhunk://#diff-58401038a90aa7cb4db244527416d6665ad0807fb5baf2751514aceeb7313c6fL7-R9) [[8]](diffhunk://#diff-58401038a90aa7cb4db244527416d6665ad0807fb5baf2751514aceeb7313c6fL25-R31)
* Added Kerberos libraries (`libgssapi-krb5-2` for Debian/Ubuntu and `krb5-libs` for Alpine) as dependencies to fix an error message in the containers. [[1]](diffhunk://#diff-3ed65642ec1610de6b0f162c77dc8499662ebeb7057d3f6c89108952d1cb33deL21-R33) [[2]](diffhunk://#diff-f1bd05d0cabc71ca98e58fb9f5bb9f51d115733d359f9d289ebc0d158b0cb2a8L21-R33) [[3]](diffhunk://#diff-434b08383a91d5e4883675176bbff7b4809a83f519bab6207710728a2c750ca8L25-R31) [[4]](diffhunk://#diff-58401038a90aa7cb4db244527416d6665ad0807fb5baf2751514aceeb7313c6fL25-R31)

**Solution structure reorganization:**

* Moved Dockerfile references in `AzzyBot.slnx` from the `/actions/` folder to a new `/docker/` folder for better organization and clarity.
* Ensured that GitHub-related configuration files are grouped under a `/github/` folder in the solution structure.