### PR TITLE
Migrate services to use interfaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,12 +6,14 @@ root = true
 # Default settings:
 # A newline ending every file
 # Use 4 spaces as indentation
+# Use UTF-8 charset
 [*]
 insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
 end_of_line = crlf
+charset = utf-8
 
 # Generated code
 [*{_AssemblyInfo.cs,.notsupported.cs,AsmOffsets.cs}]

--- a/src/AzzyBot.Bot/Commands/AdminCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AdminCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;

--- a/src/AzzyBot.Bot/Commands/AdminCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AdminCommands.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Choices;
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Helpers;
@@ -35,12 +35,12 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AdminCommands
 {
     [Command("admin"), RequireGuild, RequireApplicationOwner, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator])]
-    public sealed class AdminGroup(ILogger<AdminGroup> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordBotService botService)
+    public sealed class AdminGroup(ILogger<AdminGroup> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<AdminGroup> _logger = logger;
         private readonly AzzyBotSettings _settings = settings.Value;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly DiscordBotService _botService = botService;
+        private readonly IDiscordBotService _botService = botService;
 
         [Command("change-bot-status"), Description("Change the global bot status according to your likes.")]
         public async ValueTask ChangeStatusAsync

--- a/src/AzzyBot.Bot/Commands/AdminCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AdminCommands.cs
@@ -17,7 +17,7 @@ using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ArgumentModifiers;
@@ -35,11 +35,11 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AdminCommands
 {
     [Command("admin"), RequireGuild, RequireApplicationOwner, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator])]
-    public sealed class AdminGroup(ILogger<AdminGroup> logger, IOptions<AzzyBotSettings> settings, DbActions dbActions, DiscordBotService botService)
+    public sealed class AdminGroup(ILogger<AdminGroup> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordBotService botService)
     {
         private readonly ILogger<AdminGroup> _logger = logger;
         private readonly AzzyBotSettings _settings = settings.Value;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
         private readonly DiscordBotService _botService = botService;
 
         [Command("change-bot-status"), Description("Change the global bot status according to your likes.")]

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -23,10 +24,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, AzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
+public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, IAzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastMountAutocomplete> _logger = logger;
-    private readonly AzuraCastApiService _azuraCast = azuraCast;
+    private readonly IAzuraCastApiService _azuraCast = azuraCast;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
@@ -61,7 +62,7 @@ public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplet
             record = await _azuraCast.GetStationAsync(baseUrl, apiKey, stationId);
             if (record is null)
             {
-                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** ({stationId}) endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** ({stationId}) endpoint.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return [];
             }
         }

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
-using AzzyBot.Bot.Services;
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Records;
@@ -24,13 +23,13 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, AzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
+public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, AzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastMountAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
     private readonly IWebRequestService _webRequest = webRequest;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
@@ -13,7 +13,7 @@ using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands.Processors.SlashCommands;
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
@@ -23,12 +23,12 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, AzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, DbActions dbActions, DiscordBotService botService, WebRequestService webRequest) : IAutoCompleteProvider
+public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, AzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService, WebRequestService webRequest) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastMountAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
     private readonly WebRequestService _webRequest = webRequest;
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Records;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
@@ -23,14 +24,14 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, AzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService, WebRequestService webRequest) : IAutoCompleteProvider
+public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, AzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastMountAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
-    private readonly WebRequestService _webRequest = webRequest;
+    private readonly IWebRequestService _webRequest = webRequest;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
@@ -7,7 +7,6 @@ using System.Text;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
@@ -24,11 +23,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, IAzuraCastApiService azuraCast, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
+public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, IAzuraCastApiService azuraCast, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastMountAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCast;
-    private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
+    private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
     private readonly IWebRequestService _webRequest = webRequest;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -23,13 +23,13 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastPlaylistAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -24,11 +23,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, IAzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastPlaylistAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
-    private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
+    private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
@@ -23,10 +24,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, IAzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastPlaylistAutocomplete> _logger = logger;
-    private readonly AzuraCastApiService _azuraCast = azuraCastApi;
+    private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
@@ -65,7 +66,7 @@ public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutoc
             playlists = await _azuraCast.GetPlaylistsAsync(baseUrl, apiKey, stationId);
             if (playlists is null)
             {
-                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station ({stationId}).\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station ({stationId}).\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return [];
             }
         }

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
@@ -13,7 +13,7 @@ using AzzyBot.Core.Utilities;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Core.Utilities.Enums;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands.Processors.SlashCommands;
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
@@ -23,12 +23,12 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, DbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastPlaylistAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
@@ -11,7 +11,7 @@ using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands.Processors.SlashCommands;
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
@@ -21,11 +21,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocomplete> logger, AzuraCastApiService azuraCast, DbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocomplete> logger, AzuraCastApiService azuraCast, IDbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastRequestAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -21,12 +21,12 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocomplete> logger, AzuraCastApiService azuraCast, IDbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocomplete> logger, AzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastRequestAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastRequestAutocomplete.cs
@@ -6,7 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
@@ -21,10 +21,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocomplete> logger, AzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocomplete> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastRequestAutocomplete> _logger = logger;
-    private readonly AzuraCastApiService _azuraCast = azuraCast;
+    private readonly IAzuraCastApiService _azuraCast = azuraCast;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 
@@ -112,7 +112,7 @@ public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocom
             IEnumerable<AzuraRequestQueueItemRecord>? requests = await _azuraCast.GetStationRequestItemsAsync(baseUrl, apiKey, stationId, history: false);
             if (requests is null)
             {
-                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **requests** endpoint on station ({stationId}).\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **requests** endpoint on station ({stationId}).\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return results;
             }
 
@@ -126,7 +126,7 @@ public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocom
             AzuraAdminStationConfigRecord? config = await _azuraCast.GetStationAdminConfigAsync(baseUrl, apiKey, stationId);
             if (config is null)
             {
-                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return results;
             }
 
@@ -135,7 +135,7 @@ public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocom
                 IEnumerable<AzuraRequestRecord>? requests = await _azuraCast.GetRequestableSongsAsync(baseUrl, apiKey, stationId);
                 if (requests is null)
                 {
-                    await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **requests** endpoint on station ({stationId}).\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                    await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **requests** endpoint on station ({stationId}).\n{_azuraCast.AzuraCastPermissionsWiki}");
                     return results;
                 }
 
@@ -146,14 +146,14 @@ public sealed class AzuraCastRequestAutocomplete(ILogger<AzuraCastRequestAutocom
                 IEnumerable<AzuraFilesDetailedRecord>? filesOnline = await _azuraCast.GetFilesOnlineDetailedAsync(baseUrl, apiKey, stationId);
                 if (filesOnline is null)
                 {
-                    await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station ({stationId}).\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                    await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station ({stationId}).\n{_azuraCast.AzuraCastPermissionsWiki}");
                     return results;
                 }
 
                 IEnumerable<AzuraPlaylistRecord>? playlists = await _azuraCast.GetPlaylistsWithRequestsAsync(baseUrl, apiKey, stationId);
                 if (playlists is null)
                 {
-                    await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station ({stationId}).\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                    await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station ({stationId}).\n{_azuraCast.AzuraCastPermissionsWiki}");
                     return results;
                 }
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
@@ -12,7 +12,7 @@ using AzzyBot.Core.Utilities;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Core.Utilities.Enums;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands.Processors.SlashCommands;
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
@@ -22,12 +22,12 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, DbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastStationsAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
@@ -22,10 +23,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, IAzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastStationsAutocomplete> _logger = logger;
-    private readonly AzuraCastApiService _azuraCast = azuraCastApi;
+    private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
@@ -67,7 +68,7 @@ public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutoc
                 azuraStation = await _azuraCast.GetStationAsync(baseUrl, stationApiKey, station.StationId);
                 if (azuraStation is null)
                 {
-                    await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** (ID: {station.StationId}) endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                    await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** (ID: {station.StationId}) endpoint.\n{_azuraCast.AzuraCastPermissionsWiki}");
                     return results;
                 }
             }
@@ -83,7 +84,7 @@ public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutoc
             AzuraAdminStationConfigRecord? config = await _azuraCast.GetStationAdminConfigAsync(baseUrl, adminApiKey, station.StationId);
             if (config is null)
             {
-                await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return results;
             }
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -22,13 +22,13 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastStationsAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsAutocomplete.cs
@@ -5,7 +5,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -23,11 +22,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, IAzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastStationsAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
-    private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
+    private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -20,11 +19,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, IAzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastSystemLogAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-    private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
+    private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -19,13 +19,13 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastSystemLogAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
@@ -9,7 +9,7 @@ using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands.Processors.SlashCommands;
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
@@ -19,12 +19,12 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, DbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, DiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastSystemLogAutocomplete> _logger = logger;
     private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
@@ -19,10 +20,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, AzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, IAzuraCastApiService azuraCastApi, AzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastSystemLogAutocomplete> _logger = logger;
-    private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
+    private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
     private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
@@ -52,7 +53,7 @@ public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAut
             systemLogs = await _azuraCastApi.GetSystemLogsAsync(baseUrl, apiKey);
             if (systemLogs is null)
             {
-                await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the administrative **system logs** endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the administrative **system logs** endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return [];
             }
         }

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzzyHelpAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzzyHelpAutocomplete.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzzyViewLogsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzzyViewLogsAutocomplete.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/GuildsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/GuildsAutocomplete.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/GuildsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/GuildsAutocomplete.cs
@@ -4,7 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Settings;
 
 using DSharpPlus.Commands.Processors.SlashCommands;
@@ -15,10 +15,10 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class GuildsAutocomplete(IOptions<AzzyBotSettings> settings, DiscordBotService botService) : IAutoCompleteProvider
+public sealed class GuildsAutocomplete(IOptions<AzzyBotSettings> settings, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly AzzyBotSettings _settings = settings.Value;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -13,7 +13,6 @@ using System.Threading.Tasks;
 using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Commands.Choices;
-using AzzyBot.Bot.Services;
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities;
@@ -46,7 +45,7 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, DiscordBotService botService, MusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
@@ -54,7 +53,7 @@ public sealed class AzuraCastCommands
         private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly DiscordBotService _botService = botService;
+        private readonly IDiscordBotService _botService = botService;
         private readonly MusicStreamingService _musicStreaming = musicStreaming;
 
         [Command("export-playlists"), Description("Export all playlists from the selected AzuraCast station into a zip file."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.StationAdminGroup, AzuraCastDiscordPerm.InstanceAdminGroup]), AzuraCastOnlineCheck]
@@ -621,12 +620,12 @@ public sealed class AzuraCastCommands
     }
 
     [Command("dj"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast]), AzuraCastOnlineCheck]
-    public sealed class DjGroup(ILogger<DjGroup> logger, AzuraCastApiService azuraCast, IDbActions dbActions, DiscordBotService botService)
+    public sealed class DjGroup(ILogger<DjGroup> logger, AzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<DjGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCast = azuraCast;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly DiscordBotService _botService = botService;
+        private readonly IDiscordBotService _botService = botService;
 
         [Command("add-internal-song-request"), Description("Adds an internal song request which will be played ASAP. This bypasses the usual api."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.StationDJGroup, AzuraCastDiscordPerm.StationAdminGroup, AzuraCastDiscordPerm.InstanceAdminGroup])]
         public async ValueTask AddInternalSongRequestAsync
@@ -862,13 +861,13 @@ public sealed class AzuraCastCommands
     }
 
     [Command("music"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast]), AzuraCastOnlineCheck]
-    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, ICronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService, IWebRequestService webRequest)
+    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest)
     {
         private readonly ILogger<MusicGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCast = azuraCast;
         private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly DiscordBotService _botService = botService;
+        private readonly IDiscordBotService _botService = botService;
         private readonly IWebRequestService _webRequest = webRequest;
 
         [Command("get-song-history"), Description("Get the song history of the selected station.")]

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -14,7 +14,6 @@ using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Commands.Choices;
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;
@@ -46,7 +45,7 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
@@ -55,7 +54,7 @@ public sealed class AzuraCastCommands
         private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
-        private readonly MusicStreamingService _musicStreaming = musicStreaming;
+        private readonly IMusicStreamingService _musicStreaming = musicStreaming;
 
         [Command("export-playlists"), Description("Export all playlists from the selected AzuraCast station into a zip file."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.StationAdminGroup, AzuraCastDiscordPerm.InstanceAdminGroup]), AzuraCastOnlineCheck]
         public async ValueTask ExportPlaylistsAsync

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -46,12 +46,12 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
-        private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
+        private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -46,11 +46,11 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-        private readonly AzuraCastFileService _azuraCastFile = azuraCastFile;
+        private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -15,6 +15,7 @@ using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Commands.Choices;
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;
 using AzzyBot.Bot.Utilities.Helpers;
@@ -45,10 +46,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
-        private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
+        private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly AzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
@@ -96,7 +97,7 @@ public sealed class AzuraCastCommands
             if (playlists is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -136,7 +137,7 @@ public sealed class AzuraCastCommands
             if (azuraStation is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** endpoint on station {station}.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -333,7 +334,7 @@ public sealed class AzuraCastCommands
             if (hardwareStats is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative server stats** endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative server stats** endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -379,7 +380,7 @@ public sealed class AzuraCastCommands
             if (azuraStation is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -482,7 +483,7 @@ public sealed class AzuraCastCommands
             if (azuraStation is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -548,7 +549,7 @@ public sealed class AzuraCastCommands
             if (stationConfig is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -581,7 +582,7 @@ public sealed class AzuraCastCommands
             if (string.IsNullOrEmpty(body))
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative updates** endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative updates** endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -601,7 +602,7 @@ public sealed class AzuraCastCommands
             if (update is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative updates** endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative updates** endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -620,10 +621,10 @@ public sealed class AzuraCastCommands
     }
 
     [Command("dj"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast]), AzuraCastOnlineCheck]
-    public sealed class DjGroup(ILogger<DjGroup> logger, AzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class DjGroup(ILogger<DjGroup> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<DjGroup> _logger = logger;
-        private readonly AzuraCastApiService _azuraCast = azuraCast;
+        private readonly IAzuraCastApiService _azuraCast = azuraCast;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
 
@@ -663,7 +664,7 @@ public sealed class AzuraCastCommands
             if (stationConfig is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -677,7 +678,7 @@ public sealed class AzuraCastCommands
             if (songs is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -837,7 +838,7 @@ public sealed class AzuraCastCommands
             if (azuraStation is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -845,7 +846,7 @@ public sealed class AzuraCastCommands
             if (states is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -861,10 +862,10 @@ public sealed class AzuraCastCommands
     }
 
     [Command("music"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast]), AzuraCastOnlineCheck]
-    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest)
+    public sealed class MusicGroup(ILogger<MusicGroup> logger, IAzuraCastApiService azuraCast, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest)
     {
         private readonly ILogger<MusicGroup> _logger = logger;
-        private readonly AzuraCastApiService _azuraCast = azuraCast;
+        private readonly IAzuraCastApiService _azuraCast = azuraCast;
         private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
@@ -919,7 +920,7 @@ public sealed class AzuraCastCommands
             if (history is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **reports** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **reports** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -933,7 +934,7 @@ public sealed class AzuraCastCommands
             if (azuraStation is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -991,7 +992,7 @@ public sealed class AzuraCastCommands
                 if (playlist is null)
                 {
                     await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                    await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                    await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                     return;
                 }
             }
@@ -1005,7 +1006,7 @@ public sealed class AzuraCastCommands
             if (songs is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -1076,7 +1077,7 @@ public sealed class AzuraCastCommands
                 if (playlist is null)
                 {
                     await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                    await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                    await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **playlists** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                     return;
                 }
 
@@ -1159,7 +1160,7 @@ public sealed class AzuraCastCommands
             if (stationConfig is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative station** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -1216,7 +1217,7 @@ public sealed class AzuraCastCommands
                 if (requestsPlayed is null)
                 {
                     await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                    await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **reports** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                    await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **reports** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                     return;
                 }
 
@@ -1229,7 +1230,7 @@ public sealed class AzuraCastCommands
             if (stationQueue is null || requestsPending is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **queue** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **queue** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 
@@ -1344,7 +1345,7 @@ public sealed class AzuraCastCommands
             if (uploadedFile is null || azuraStation is null)
             {
                 await context.EditResponseAsync(GeneralStrings.PermissionIssue);
-                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station {station}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(ac.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station {station}.\n{_azuraCast.AzuraCastPermissionsWiki}");
                 return;
             }
 

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -796,7 +796,7 @@ public sealed class AzuraCastCommands
 
             await _azuraCast.SkipSongAsync(baseUrl, apiKey, station);
 
-            await _dbActions.UpdateAzuraCastStationAsync(context.Guild.Id, station, null, null, true);
+            await _dbActions.UpdateAzuraCastStationAsync(context.Guild.Id, station, updateLastSkipTime: true);
 
             await context.EditResponseAsync($"I skipped **{nowPlaying.NowPlaying.Song.Title}** by **{nowPlaying.NowPlaying.Song.Artist}**.");
         }

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -46,13 +46,13 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, MusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
-        private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
+        private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
         private readonly MusicStreamingService _musicStreaming = musicStreaming;

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -14,6 +14,7 @@ using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Commands.Choices;
 using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;
@@ -861,11 +862,11 @@ public sealed class AzuraCastCommands
     }
 
     [Command("music"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast]), AzuraCastOnlineCheck]
-    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, CronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService, WebRequestService webRequest)
+    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, ICronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService, WebRequestService webRequest)
     {
         private readonly ILogger<MusicGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCast = azuraCast;
-        private readonly CronJobManager _cronJobManager = cronJobManager;
+        private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
         private readonly DiscordBotService _botService = botService;
         private readonly WebRequestService _webRequest = webRequest;

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -862,14 +862,14 @@ public sealed class AzuraCastCommands
     }
 
     [Command("music"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast]), AzuraCastOnlineCheck]
-    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, ICronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService, WebRequestService webRequest)
+    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, ICronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService, IWebRequestService webRequest)
     {
         private readonly ILogger<MusicGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCast = azuraCast;
         private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
         private readonly DiscordBotService _botService = botService;
-        private readonly WebRequestService _webRequest = webRequest;
+        private readonly IWebRequestService _webRequest = webRequest;
 
         [Command("get-song-history"), Description("Get the song history of the selected station.")]
         public async ValueTask GetSongHistoryAsync

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -493,7 +493,7 @@ public sealed class AzuraCastCommands
                 await _musicStreaming.StopMusicAsync(context);
 
                 DiscordMember? bot = await _botService.GetDiscordMemberAsync(context.Guild.Id);
-                 if (bot?.VoiceState?.ChannelId is not null && await bot.VoiceState.GetChannelAsync() is DiscordChannel botChannel)
+                if (bot?.VoiceState?.ChannelId is not null && await bot.VoiceState.GetChannelAsync() is DiscordChannel botChannel)
                     await botChannel.SendMessageAsync(GeneralStrings.VoiceStationStopped);
 
                 await context.EditResponseAsync(GeneralStrings.StationUsersDisconnected);

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -25,7 +25,7 @@ using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Core.Utilities.Enums;
 using AzzyBot.Core.Utilities.Helpers;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
@@ -45,14 +45,14 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, DbActions dbActions, DiscordBotService botService, MusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, DiscordBotService botService, MusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly AzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
         private readonly DiscordBotService _botService = botService;
         private readonly MusicStreamingService _musicStreaming = musicStreaming;
 
@@ -620,11 +620,11 @@ public sealed class AzuraCastCommands
     }
 
     [Command("dj"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast]), AzuraCastOnlineCheck]
-    public sealed class DjGroup(ILogger<DjGroup> logger, AzuraCastApiService azuraCast, DbActions dbActions, DiscordBotService botService)
+    public sealed class DjGroup(ILogger<DjGroup> logger, AzuraCastApiService azuraCast, IDbActions dbActions, DiscordBotService botService)
     {
         private readonly ILogger<DjGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCast = azuraCast;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
         private readonly DiscordBotService _botService = botService;
 
         [Command("add-internal-song-request"), Description("Adds an internal song request which will be played ASAP. This bypasses the usual api."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.StationDJGroup, AzuraCastDiscordPerm.StationAdminGroup, AzuraCastDiscordPerm.InstanceAdminGroup])]
@@ -861,12 +861,12 @@ public sealed class AzuraCastCommands
     }
 
     [Command("music"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast]), AzuraCastOnlineCheck]
-    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, CronJobManager cronJobManager, DbActions dbActions, DiscordBotService botService, WebRequestService webRequest)
+    public sealed class MusicGroup(ILogger<MusicGroup> logger, AzuraCastApiService azuraCast, CronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService, WebRequestService webRequest)
     {
         private readonly ILogger<MusicGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCast = azuraCast;
         private readonly CronJobManager _cronJobManager = cronJobManager;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
         private readonly DiscordBotService _botService = botService;
         private readonly WebRequestService _webRequest = webRequest;
 

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordChannelCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordChannelCheck.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordChannelCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordChannelCheck.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
@@ -24,10 +24,10 @@ namespace AzzyBot.Bot.Commands.Checks;
 /// This check ensures that specific commands are executed in the appropriate Discord channel as defined in the AzuraCast
 /// station preferences. If the command is executed in an incorrect channel, the check returns the expected channel ID and fails.
 /// </remarks>
-public sealed class AzuraCastDiscordChannelCheck(ILogger<AzuraCastDiscordChannelCheck> logger, DbActions dbActions) : IContextCheck<AzuraCastDiscordChannelCheckAttribute>
+public sealed class AzuraCastDiscordChannelCheck(ILogger<AzuraCastDiscordChannelCheck> logger, IDbActions dbActions) : IContextCheck<AzuraCastDiscordChannelCheckAttribute>
 {
     private readonly ILogger<AzuraCastDiscordChannelCheck> _logger = logger;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
 
     public async ValueTask<string?> ExecuteCheckAsync(AzuraCastDiscordChannelCheckAttribute attribute, CommandContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordChannelCheckAttribute.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordChannelCheckAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using DSharpPlus.Commands.ContextChecks;
 

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordPermCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordPermCheck.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordPermCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordPermCheck.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using AzzyBot.Bot.Utilities.Enums;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
@@ -26,10 +26,10 @@ namespace AzzyBot.Bot.Commands.Checks;
 /// This check ensures that specific commands are executed with specific permissions only defined in the database preferences.
 /// If the command is executed by an unauthorized user it returns a string and fails.
 /// </remarks>
-public class AzuraCastDiscordPermCheck(ILogger<AzuraCastDiscordPermCheck> logger, DbActions dbActions) : IContextCheck<AzuraCastDiscordPermCheckAttribute>
+public class AzuraCastDiscordPermCheck(ILogger<AzuraCastDiscordPermCheck> logger, IDbActions dbActions) : IContextCheck<AzuraCastDiscordPermCheckAttribute>
 {
     private readonly ILogger<AzuraCastDiscordPermCheck> _logger = logger;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
 
     [SuppressMessage("Style", "IDE0066:Convert switch statement to expression", Justification = "Better reading style")]
     public async ValueTask<string?> ExecuteCheckAsync(AzuraCastDiscordPermCheckAttribute attribute, CommandContext context)

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordPermCheckAttribute.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastDiscordPermCheckAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using AzzyBot.Bot.Utilities.Enums;
 

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastFeatureCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastFeatureCheck.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using AzzyBot.Bot.Utilities.Enums;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
@@ -17,10 +17,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Checks;
 
-public sealed class FeatureAvailableCheck(ILogger<FeatureAvailableCheck> logger, DbActions dbActions) : IContextCheck<FeatureAvailableCheckAttribute>
+public sealed class FeatureAvailableCheck(ILogger<FeatureAvailableCheck> logger, IDbActions dbActions) : IContextCheck<FeatureAvailableCheckAttribute>
 {
     private readonly ILogger<FeatureAvailableCheck> _logger = logger;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
 
     public async ValueTask<string?> ExecuteCheckAsync(FeatureAvailableCheckAttribute attribute, CommandContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastOnlineCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastOnlineCheck.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
@@ -14,9 +14,9 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Checks;
 
-public sealed class AzuraCastOnlineCheck(ILogger<AzuraCastOnlineCheck> logger, DbActions dbActions) : IContextCheck<AzuraCastOnlineCheckAttribute>
+public sealed class AzuraCastOnlineCheck(ILogger<AzuraCastOnlineCheck> logger, IDbActions dbActions) : IContextCheck<AzuraCastOnlineCheckAttribute>
 {
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
 
     public async ValueTask<string?> ExecuteCheckAsync(AzuraCastOnlineCheckAttribute attribute, CommandContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastOnlineCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastOnlineCheck.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using AzzyBot.Core.Logging;

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastOnlineCheckAttribute.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastOnlineCheckAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using DSharpPlus.Commands.ContextChecks;
 

--- a/src/AzzyBot.Bot/Commands/Checks/ModuleActivatedCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/ModuleActivatedCheck.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Utilities.Enums;

--- a/src/AzzyBot.Bot/Commands/Checks/ModuleActivatedCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/ModuleActivatedCheck.cs
@@ -5,7 +5,7 @@ using AzzyBot.Bot.Utilities.Enums;
 using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
@@ -16,10 +16,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Checks;
 
-public sealed class ModuleActivatedCheck(ILogger<ModuleActivatedCheck> logger, DbActions dbActions) : IContextCheck<ModuleActivatedCheckAttribute>
+public sealed class ModuleActivatedCheck(ILogger<ModuleActivatedCheck> logger, IDbActions dbActions) : IContextCheck<ModuleActivatedCheckAttribute>
 {
     private readonly ILogger<ModuleActivatedCheck> _logger = logger;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
 
     public async ValueTask<string?> ExecuteCheckAsync(ModuleActivatedCheckAttribute attribute, CommandContext context)
     {

--- a/src/AzzyBot.Bot/Commands/Checks/ModuleActivatedCheckAttribute.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/ModuleActivatedCheckAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using AzzyBot.Bot.Utilities.Enums;
 

--- a/src/AzzyBot.Bot/Commands/Choices/AzuraExportPlaylistProvider.cs
+++ b/src/AzzyBot.Bot/Commands/Choices/AzuraExportPlaylistProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;

--- a/src/AzzyBot.Bot/Commands/Choices/BooleanEnabledDisabledStateProvider.cs
+++ b/src/AzzyBot.Bot/Commands/Choices/BooleanEnabledDisabledStateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;

--- a/src/AzzyBot.Bot/Commands/Choices/BooleanYesNoStateProvider.cs
+++ b/src/AzzyBot.Bot/Commands/Choices/BooleanYesNoStateProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;

--- a/src/AzzyBot.Bot/Commands/Choices/BotActivityProvider.cs
+++ b/src/AzzyBot.Bot/Commands/Choices/BotActivityProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;

--- a/src/AzzyBot.Bot/Commands/Choices/BotStatusProvider.cs
+++ b/src/AzzyBot.Bot/Commands/Choices/BotStatusProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;

--- a/src/AzzyBot.Bot/Commands/Choices/MusicStreamingPlatformProvider.cs
+++ b/src/AzzyBot.Bot/Commands/Choices/MusicStreamingPlatformProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -43,12 +43,12 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
-        private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
+        private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -43,11 +43,11 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-        private readonly AzuraCastFileService _azuraCastFile = azuraCastFile;
+        private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -13,6 +13,7 @@ using AzzyBot.Bot.Commands.Choices;
 using AzzyBot.Bot.Resources;
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;
 using AzzyBot.Bot.Utilities.Helpers;
@@ -42,10 +43,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
-        private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
+        private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly AzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
@@ -632,13 +633,13 @@ public sealed class ConfigCommands
                         catch (InvalidOperationException)
                         {
                             // This can happen when the permissions are not sufficient to access the station
-                            await _botService.SendMessageAsync(guild.AzuraCast.Preferences.NotificationChannelId, $"I can't access the **station** ({station.StationId}) endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}. Maybe also check if the API key is valid.");
+                            await _botService.SendMessageAsync(guild.AzuraCast.Preferences.NotificationChannelId, $"I can't access the **station** ({station.StationId}) endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}. Maybe also check if the API key is valid.");
                             continue;
                         }
 
                         string stationName = stationRecord?.Name ?? "Station unaccessible.";
                         if (stationRecord is null)
-                            await _botService.SendMessageAsync(guild.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** ({station.StationId}) endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                            await _botService.SendMessageAsync(guild.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** ({station.StationId}) endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
 
                         stationNames.Add(station.Id, stationName);
 

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -43,13 +43,13 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
-        private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
+        private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -11,7 +11,7 @@ using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Commands.Choices;
 using AzzyBot.Bot.Resources;
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;
@@ -42,7 +42,7 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, DiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
@@ -50,7 +50,7 @@ public sealed class ConfigCommands
         private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly DiscordBotService _botService = botService;
+        private readonly IDiscordBotService _botService = botService;
 
         [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This is just a hard check.")]
         [Command("add-azuracast"), Description("Add an AzuraCast instance to your server. This is a requirement to use the features.")]

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -22,7 +22,7 @@ using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ArgumentModifiers;
@@ -42,14 +42,14 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, DbActions dbActions, DiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, AzuraCastApiService azuraCastApi, AzuraCastFileService azuraCastFile, AzuraCastPingService azuraCastPing, AzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, DiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly AzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly AzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly AzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
         private readonly DiscordBotService _botService = botService;
 
         [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "This is just a hard check.")]
@@ -686,10 +686,10 @@ public sealed class ConfigCommands
     }
 
     [Command("legals"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator])]
-    public sealed class LegalsGroup(ILogger<LegalsGroup> logger, DbActions dbActions)
+    public sealed class LegalsGroup(ILogger<LegalsGroup> logger, IDbActions dbActions)
     {
         private readonly ILogger<LegalsGroup> _logger = logger;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
 
         [Command("accept-legals"), Description("Provides you the links and guides you through the steps how to accept the legal conditions.")]
         public async ValueTask AcceptLegalsAsync(SlashCommandContext context)

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -633,7 +633,7 @@ public sealed class ConfigCommands
                         catch (InvalidOperationException)
                         {
                             // This can happen when the permissions are not sufficient to access the station
-                            await _botService.SendMessageAsync(guild.AzuraCast.Preferences.NotificationChannelId, $"I can't access the **station** ({station.StationId}) endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}. Maybe also check if the API key is valid.");
+                            await _botService.SendMessageAsync(guild.AzuraCast.Preferences.NotificationChannelId, $"I can't access the **station** ({station.StationId}) endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki} Maybe also check if the API key is valid.");
                             continue;
                         }
 

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -12,7 +12,6 @@ using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Commands.Choices;
 using AzzyBot.Bot.Resources;
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;

--- a/src/AzzyBot.Bot/Commands/Converters/UriArgumentConverter.cs
+++ b/src/AzzyBot.Bot/Commands/Converters/UriArgumentConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using DSharpPlus.Commands.Converters;

--- a/src/AzzyBot.Bot/Commands/CoreCommands.cs
+++ b/src/AzzyBot.Bot/Commands/CoreCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;

--- a/src/AzzyBot.Bot/Commands/CoreCommands.cs
+++ b/src/AzzyBot.Bot/Commands/CoreCommands.cs
@@ -16,7 +16,7 @@ using AzzyBot.Bot.Utilities.Records;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Records;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
@@ -33,11 +33,11 @@ namespace AzzyBot.Bot.Commands;
 public sealed class CoreCommands
 {
     [Command("core"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class CoreGroup(ILogger<CoreGroup> logger, IOptions<AzzyBotSettings> settings, DbActions dbActions, DiscordBotService botService)
+    public sealed class CoreGroup(ILogger<CoreGroup> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordBotService botService)
     {
         private readonly ILogger<CoreGroup> _logger = logger;
         private readonly AzzyBotSettings _settings = settings.Value;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
         private readonly DiscordBotService _botService = botService;
 
         [Command("force-channel-permissions-check"), Description("Forces a check of the permissions for the bot in the necessary channel."), RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator])]

--- a/src/AzzyBot.Bot/Commands/CoreCommands.cs
+++ b/src/AzzyBot.Bot/Commands/CoreCommands.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Checks;
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;
@@ -33,12 +33,12 @@ namespace AzzyBot.Bot.Commands;
 public sealed class CoreCommands
 {
     [Command("core"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class CoreGroup(ILogger<CoreGroup> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordBotService botService)
+    public sealed class CoreGroup(ILogger<CoreGroup> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<CoreGroup> _logger = logger;
         private readonly AzzyBotSettings _settings = settings.Value;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly DiscordBotService _botService = botService;
+        private readonly IDiscordBotService _botService = botService;
 
         [Command("force-channel-permissions-check"), Description("Forces a check of the permissions for the bot in the necessary channel."), RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator])]
         public async ValueTask ForceChannelPermissionsCheckAsync(SlashCommandContext context)

--- a/src/AzzyBot.Bot/Commands/DebugCommands.cs
+++ b/src/AzzyBot.Bot/Commands/DebugCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;

--- a/src/AzzyBot.Bot/Commands/DebugCommands.cs
+++ b/src/AzzyBot.Bot/Commands/DebugCommands.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Choices;
-using AzzyBot.Bot.Services;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
@@ -30,11 +30,11 @@ namespace AzzyBot.Bot.Commands;
 public sealed class DebugCommands
 {
     [Command("debug"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator])]
-    public sealed class DebugGroup(ILogger<DebugGroup> logger, IDbActions dbActions, WebRequestService webRequestService)
+    public sealed class DebugGroup(ILogger<DebugGroup> logger, IDbActions dbActions, IWebRequestService webRequestService)
     {
         private readonly ILogger<DebugGroup> _logger = logger;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly WebRequestService _webRequestService = webRequestService;
+        private readonly IWebRequestService _webRequestService = webRequestService;
 
         [Command("cluster-logging"), Description("Test the logging file rotation feature of the bot.")]
         public async ValueTask DebugClusterLoggingAsync

--- a/src/AzzyBot.Bot/Commands/DebugCommands.cs
+++ b/src/AzzyBot.Bot/Commands/DebugCommands.cs
@@ -13,7 +13,7 @@ using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ArgumentModifiers;
@@ -30,10 +30,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class DebugCommands
 {
     [Command("debug"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator])]
-    public sealed class DebugGroup(ILogger<DebugGroup> logger, DbActions dbActions, WebRequestService webRequestService)
+    public sealed class DebugGroup(ILogger<DebugGroup> logger, IDbActions dbActions, WebRequestService webRequestService)
     {
         private readonly ILogger<DebugGroup> _logger = logger;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
         private readonly WebRequestService _webRequestService = webRequestService;
 
         [Command("cluster-logging"), Description("Test the logging file rotation feature of the bot.")]

--- a/src/AzzyBot.Bot/Commands/DebugCommands.cs
+++ b/src/AzzyBot.Bot/Commands/DebugCommands.cs
@@ -93,7 +93,7 @@ public sealed class DebugCommands
             {
                 if (value is 1)
                 {
-                    await _dbActions.UpdateGuildAsync(guildEntity.UniqueId, lastPermissionCheck: true);
+                    await _dbActions.UpdateGuildAsync(guildEntity.UniqueId, updateLastPermissionCheck: true);
                     sb.AppendLine("Changed LastPermissionCheck to true");
                 }
                 else if (value is 2)

--- a/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
+++ b/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;

--- a/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
+++ b/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
@@ -18,7 +18,7 @@ using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Commands;
 using DSharpPlus.Commands.ContextChecks;
@@ -38,11 +38,11 @@ namespace AzzyBot.Bot.Commands;
 public sealed class MusicStreamingCommands
 {
     [Command("player"), RequireGuild, RequirePermissions(botPermissions: [DiscordPermission.Connect, DiscordPermission.Speak], userPermissions: [DiscordPermission.Connect]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class PlayerGroup(ILogger<PlayerGroup> logger, AzuraCastApiService azuraCast, DbActions dbActions, MusicStreamingService musicStreaming)
+    public sealed class PlayerGroup(ILogger<PlayerGroup> logger, AzuraCastApiService azuraCast, IDbActions dbActions, MusicStreamingService musicStreaming)
     {
         private readonly ILogger<PlayerGroup> _logger = logger;
         private readonly AzuraCastApiService _azuraCast = azuraCast;
-        private readonly DbActions _dbActions = dbActions;
+        private readonly IDbActions _dbActions = dbActions;
         private readonly MusicStreamingService _musicStreaming = musicStreaming;
         private static readonly string AppName = SoftwareStats.GetAppName;
 

--- a/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
+++ b/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
@@ -10,6 +10,7 @@ using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Commands.Choices;
 using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;
 using AzzyBot.Bot.Utilities.Helpers;
@@ -38,10 +39,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class MusicStreamingCommands
 {
     [Command("player"), RequireGuild, RequirePermissions(botPermissions: [DiscordPermission.Connect, DiscordPermission.Speak], userPermissions: [DiscordPermission.Connect]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class PlayerGroup(ILogger<PlayerGroup> logger, AzuraCastApiService azuraCast, IDbActions dbActions, MusicStreamingService musicStreaming)
+    public sealed class PlayerGroup(ILogger<PlayerGroup> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, MusicStreamingService musicStreaming)
     {
         private readonly ILogger<PlayerGroup> _logger = logger;
-        private readonly AzuraCastApiService _azuraCast = azuraCast;
+        private readonly IAzuraCastApiService _azuraCast = azuraCast;
         private readonly IDbActions _dbActions = dbActions;
         private readonly MusicStreamingService _musicStreaming = musicStreaming;
         private static readonly string AppName = SoftwareStats.GetAppName;

--- a/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
+++ b/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
@@ -9,7 +9,6 @@ using System.Threading.Tasks;
 using AzzyBot.Bot.Commands.Autocompletes;
 using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Commands.Choices;
-using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Enums;
@@ -39,12 +38,12 @@ namespace AzzyBot.Bot.Commands;
 public sealed class MusicStreamingCommands
 {
     [Command("player"), RequireGuild, RequirePermissions(botPermissions: [DiscordPermission.Connect, DiscordPermission.Speak], userPermissions: [DiscordPermission.Connect]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class PlayerGroup(ILogger<PlayerGroup> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, MusicStreamingService musicStreaming)
+    public sealed class PlayerGroup(ILogger<PlayerGroup> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IMusicStreamingService musicStreaming)
     {
         private readonly ILogger<PlayerGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCast = azuraCast;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly MusicStreamingService _musicStreaming = musicStreaming;
+        private readonly IMusicStreamingService _musicStreaming = musicStreaming;
         private static readonly string AppName = SoftwareStats.GetAppName;
 
         [Command("change-volume"), Description("Change the volume of the played music.")]

--- a/src/AzzyBot.Bot/Extensions/IHostExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IHostExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -76,7 +76,7 @@ public static class IServiceCollectionExtensions
 
             services.AddSingleton<IAzuraCastApiService, AzuraCastApiService>();
             services.AddSingleton<IAzuraCastFileService, AzuraCastFileService>();
-            services.AddSingleton<AzuraCastPingService>();
+            services.AddSingleton<IAzuraCastPingService, AzuraCastPingService>();
             services.AddSingleton<AzuraCastUpdateService>();
             services.AddNCronJob(o =>
             {

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -59,8 +59,8 @@ public static class IServiceCollectionExtensions
             services.DiscordClientCommands(botSettings);
             services.DiscordClientInteractivity();
 
-            services.AddSingleton<DiscordBotService>();
-            services.AddSingleton<DiscordBotServiceHost>().AddHostedService(static s => s.GetRequiredService<DiscordBotServiceHost>());
+            services.AddSingleton<IDiscordBotService, DiscordBotService>();
+            services.AddSingleton<IDiscordBotServiceHost, DiscordBotServiceHost>().AddHostedService(static s => s.GetRequiredService<IDiscordBotServiceHost>());
             services.AddSingleton<CoreService>();
 
             services.AddHttpClient(SoftwareStats.GetAppName, static c =>

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using AzzyBot.Bot.Services.CronJobs;
 using AzzyBot.Bot.Services.DiscordEvents;
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Settings.Validators;
 using AzzyBot.Core.Utilities;
@@ -73,7 +74,7 @@ public static class IServiceCollectionExtensions
             services.AddSingleton<IWebRequestService, WebRequestService>();
             services.AddSingleton<IUpdaterService, UpdaterService>();
 
-            services.AddSingleton<AzuraCastApiService>();
+            services.AddSingleton<IAzuraCastApiService, AzuraCastApiService>();
             services.AddSingleton<AzuraCastFileService>();
             services.AddSingleton<AzuraCastPingService>();
             services.AddSingleton<AzuraCastUpdateService>();

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -71,7 +71,7 @@ public static class IServiceCollectionExtensions
                 c.Timeout = TimeSpan.FromSeconds(30);
             });
             services.AddSingleton<WebRequestService>();
-            services.AddSingleton<UpdaterService>();
+            services.AddSingleton<IUpdaterService, UpdaterService>();
 
             services.AddSingleton<AzuraCastApiService>();
             services.AddSingleton<AzuraCastFileService>();

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -146,7 +146,7 @@ public static class IServiceCollectionExtensions
                 config.ReadyTimeout = TimeSpan.FromSeconds(30);
                 config.ResumptionOptions = new(TimeSpan.Zero);
             });
-            services.AddSingleton<MusicStreamingService>();
+            services.AddSingleton<IMusicStreamingService, MusicStreamingService>();
         }
 
         public void AddAppSettings(string settingsFile)

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -77,7 +77,7 @@ public static class IServiceCollectionExtensions
             services.AddSingleton<IAzuraCastApiService, AzuraCastApiService>();
             services.AddSingleton<IAzuraCastFileService, AzuraCastFileService>();
             services.AddSingleton<IAzuraCastPingService, AzuraCastPingService>();
-            services.AddSingleton<AzuraCastUpdateService>();
+            services.AddSingleton<IAzuraCastUpdateService, AzuraCastUpdateService>();
             services.AddNCronJob(o =>
             {
 #if DEBUG && !DOCKER_DEBUG

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -70,7 +70,7 @@ public static class IServiceCollectionExtensions
                 c.DefaultVersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
                 c.Timeout = TimeSpan.FromSeconds(30);
             });
-            services.AddSingleton<WebRequestService>();
+            services.AddSingleton<IWebRequestService, WebRequestService>();
             services.AddSingleton<IUpdaterService, UpdaterService>();
 
             services.AddSingleton<AzuraCastApiService>();

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using AzzyBot.Bot.Commands.Converters;
 using AzzyBot.Bot.Services;
 using AzzyBot.Bot.Services.CronJobs;
 using AzzyBot.Bot.Services.DiscordEvents;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Settings.Validators;
@@ -106,7 +107,7 @@ public static class IServiceCollectionExtensions
                 o.AddJob<LogfileCleaningJob>(j => j.WithName(nameof(LogfileCleaningJob)).WithCronExpression(everyDay).WithParameter(logDays).RunAtStartup());
                 o.AddJob<MusicStreamingPersistentNowPlayingJob>(j => j.WithName(nameof(MusicStreamingPersistentNowPlayingJob)).WithCronExpression(everyMinute));
             });
-            services.AddSingleton<CronJobManager>();
+            services.AddSingleton<ICronJobManager, CronJobManager>();
 
             services.AddLavalink();
             services.ConfigureLavalink(config =>

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -75,7 +75,7 @@ public static class IServiceCollectionExtensions
             services.AddSingleton<IUpdaterService, UpdaterService>();
 
             services.AddSingleton<IAzuraCastApiService, AzuraCastApiService>();
-            services.AddSingleton<AzuraCastFileService>();
+            services.AddSingleton<IAzuraCastFileService, AzuraCastFileService>();
             services.AddSingleton<AzuraCastPingService>();
             services.AddSingleton<AzuraCastUpdateService>();
             services.AddNCronJob(o =>

--- a/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Bot/Extensions/IServiceCollectionExtensions.cs
@@ -51,7 +51,7 @@ public static class IServiceCollectionExtensions
 
             // Need to register as Singleton first
             // Otherwise DI doesn't work properly
-            services.AddSingleton<CoreServiceHost>().AddHostedService(static s => s.GetRequiredService<CoreServiceHost>());
+            services.AddSingleton<ICoreServiceHost, CoreServiceHost>().AddHostedService(static s => s.GetRequiredService<ICoreServiceHost>());
 
             // Register the database services
             services.AzzyBotDataServices(dbSettings);
@@ -62,7 +62,7 @@ public static class IServiceCollectionExtensions
 
             services.AddSingleton<IDiscordBotService, DiscordBotService>();
             services.AddSingleton<IDiscordBotServiceHost, DiscordBotServiceHost>().AddHostedService(static s => s.GetRequiredService<IDiscordBotServiceHost>());
-            services.AddSingleton<CoreService>();
+            services.AddSingleton<ICoreService, CoreService>();
 
             services.AddHttpClient(SoftwareStats.GetAppName, static c =>
             {

--- a/src/AzzyBot.Bot/Program.cs
+++ b/src/AzzyBot.Bot/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 #if DOCKER_DEBUG || DOCKER
 using System.Globalization;
 #endif

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -3,13 +3,14 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.CronJobs;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 
 using NCronJob;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class CronJobManager(IInstantJobRegistry jobRegistry, DiscordBotService botService) : IExceptionHandler
+public sealed class CronJobManager(IInstantJobRegistry jobRegistry, DiscordBotService botService) : ICronJobManager
 {
     private readonly IInstantJobRegistry _jobRegistry = jobRegistry;
     private readonly DiscordBotService _botService = botService;

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -10,10 +10,10 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class CronJobManager(IInstantJobRegistry jobRegistry, DiscordBotService botService) : ICronJobManager
+public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotService botService) : ICronJobManager
 {
     private readonly IInstantJobRegistry _jobRegistry = jobRegistry;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public void RunAzzyBotInactiveGuildJob()
         => _jobRegistry.RunInstantJob<AzzyBotInactiveGuildJob>();

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
@@ -6,16 +6,16 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckApiPermissionsJob(AzuraCastApiService apiService, DbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraCheckApiPermissionsJob(AzuraCastApiService apiService, IDbActions dbActions, DiscordBotService botService) : IJob
 {
     private readonly AzuraCastApiService _apiService = apiService;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
 
@@ -13,9 +13,9 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckApiPermissionsJob(AzuraCastApiService apiService, IDbActions dbActions, IDiscordBotService botService) : IJob
+public sealed class AzuraCheckApiPermissionsJob(IAzuraCastApiService apiService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
-    private readonly AzuraCastApiService _apiService = apiService;
+    private readonly IAzuraCastApiService _apiService = apiService;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
@@ -12,11 +13,11 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckApiPermissionsJob(AzuraCastApiService apiService, IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraCheckApiPermissionsJob(AzuraCastApiService apiService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly AzuraCastApiService _apiService = apiService;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
 
@@ -13,9 +13,9 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckFileChangesJob(AzuraCastFileService azuraFileService, IDbActions dbActions, IDiscordBotService botService) : IJob
+public sealed class AzuraCheckFileChangesJob(IAzuraCastFileService azuraFileService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
-    private readonly AzuraCastFileService _azuraFileService = azuraFileService;
+    private readonly IAzuraCastFileService _azuraFileService = azuraFileService;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
@@ -12,11 +13,11 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckFileChangesJob(AzuraCastFileService azuraFileService, IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraCheckFileChangesJob(AzuraCastFileService azuraFileService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly AzuraCastFileService _azuraFileService = azuraFileService;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
@@ -6,16 +6,16 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckFileChangesJob(AzuraCastFileService azuraFileService, DbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraCheckFileChangesJob(AzuraCastFileService azuraFileService, IDbActions dbActions, DiscordBotService botService) : IJob
 {
     private readonly AzuraCastFileService _azuraFileService = azuraFileService;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
@@ -6,16 +6,16 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckUpdatesJob(AzuraCastUpdateService azuraUpdateService, DbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraCheckUpdatesJob(AzuraCastUpdateService azuraUpdateService, IDbActions dbActions, DiscordBotService botService) : IJob
 {
     private readonly AzuraCastUpdateService _azuraUpdateService = azuraUpdateService;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
@@ -12,11 +13,11 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckUpdatesJob(AzuraCastUpdateService azuraUpdateService, IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraCheckUpdatesJob(AzuraCastUpdateService azuraUpdateService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly AzuraCastUpdateService _azuraUpdateService = azuraUpdateService;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
 
@@ -13,9 +13,9 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraCheckUpdatesJob(AzuraCastUpdateService azuraUpdateService, IDbActions dbActions, IDiscordBotService botService) : IJob
+public sealed class AzuraCheckUpdatesJob(IAzuraCastUpdateService azuraUpdateService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
-    private readonly AzuraCastUpdateService _azuraUpdateService = azuraUpdateService;
+    private readonly IAzuraCastUpdateService _azuraUpdateService = azuraUpdateService;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -22,10 +22,10 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraPersistentNowPlayingJob(ILogger<AzuraPersistentNowPlayingJob> logger, AzuraCastApiService apiService, IDbActions dbActions, IDiscordBotService botService) : IJob
+public sealed class AzuraPersistentNowPlayingJob(ILogger<AzuraPersistentNowPlayingJob> logger, IAzuraCastApiService apiService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<AzuraPersistentNowPlayingJob> _logger = logger;
-    private readonly AzuraCastApiService _apiService = apiService;
+    private readonly IAzuraCastApiService _apiService = apiService;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
@@ -10,7 +10,7 @@ using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Entities;
 using DSharpPlus.Exceptions;
@@ -21,11 +21,11 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraPersistentNowPlayingJob(ILogger<AzuraPersistentNowPlayingJob> logger, AzuraCastApiService apiService, DbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraPersistentNowPlayingJob(ILogger<AzuraPersistentNowPlayingJob> logger, AzuraCastApiService apiService, IDbActions dbActions, DiscordBotService botService) : IJob
 {
     private readonly ILogger<AzuraPersistentNowPlayingJob> _logger = logger;
     private readonly AzuraCastApiService _apiService = apiService;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
@@ -21,12 +22,12 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraPersistentNowPlayingJob(ILogger<AzuraPersistentNowPlayingJob> logger, AzuraCastApiService apiService, IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraPersistentNowPlayingJob(ILogger<AzuraPersistentNowPlayingJob> logger, AzuraCastApiService apiService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<AzuraPersistentNowPlayingJob> _logger = logger;
     private readonly AzuraCastApiService _apiService = apiService;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
@@ -4,7 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
@@ -16,10 +16,10 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, AzuraCastApiService apiService, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService) : IJob
+public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, IAzuraCastApiService apiService, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<AzuraRequestJob> _logger = logger;
-    private readonly AzuraCastApiService _apiService = apiService;
+    private readonly IAzuraCastApiService _apiService = apiService;
     private readonly ICronJobManager _cronJobManager = cronJobManager;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
@@ -55,7 +55,7 @@ public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, IAzuraCastA
             try
             {
                 await _apiService.RequestSongAsync(record.BaseUri, record.StationId, record.RequestId);
-                await _dbActions.UpdateAzuraCastStationAsync(record.GuildId, record.StationId, lastRequestTime: true);
+                await _dbActions.UpdateAzuraCastStationAsync(record.GuildId, record.StationId, updateLastRequestTime: true);
                 await _dbActions.CreateAzuraCastStationRequestAsync(record.GuildId, record.StationId, record.SongId);
 
                 _logger.BackgroundServiceSongRequestFinished(record.RequestId, station.AzuraCast.GuildId, station.AzuraCastId, station.Id, station.StationId);

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
@@ -16,13 +16,13 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, AzuraCastApiService apiService, ICronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, AzuraCastApiService apiService, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<AzuraRequestJob> _logger = logger;
     private readonly AzuraCastApiService _apiService = apiService;
     private readonly ICronJobManager _cronJobManager = cronJobManager;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -15,11 +16,11 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, AzuraCastApiService apiService, CronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, AzuraCastApiService apiService, ICronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService) : IJob
 {
     private readonly ILogger<AzuraRequestJob> _logger = logger;
     private readonly AzuraCastApiService _apiService = apiService;
-    private readonly CronJobManager _cronJobManager = cronJobManager;
+    private readonly ICronJobManager _cronJobManager = cronJobManager;
     private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraRequestJob.cs
@@ -7,7 +7,7 @@ using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using Microsoft.Extensions.Logging;
 
@@ -15,12 +15,12 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, AzuraCastApiService apiService, CronJobManager cronJobManager, DbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraRequestJob(ILogger<AzuraRequestJob> logger, AzuraCastApiService apiService, CronJobManager cronJobManager, IDbActions dbActions, DiscordBotService botService) : IJob
 {
     private readonly ILogger<AzuraRequestJob> _logger = logger;
     private readonly AzuraCastApiService _apiService = apiService;
     private readonly CronJobManager _cronJobManager = cronJobManager;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
@@ -6,16 +6,16 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraStatusPingJob(AzuraCastPingService pingService, DbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraStatusPingJob(AzuraCastPingService pingService, IDbActions dbActions, DiscordBotService botService) : IJob
 {
     private readonly AzuraCastPingService _pingService = pingService;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
@@ -12,11 +13,11 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraStatusPingJob(AzuraCastPingService pingService, IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzuraStatusPingJob(AzuraCastPingService pingService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly AzuraCastPingService _pingService = pingService;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
 
@@ -13,9 +13,9 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzuraStatusPingJob(AzuraCastPingService pingService, IDbActions dbActions, IDiscordBotService botService) : IJob
+public sealed class AzuraStatusPingJob(IAzuraCastPingService pingService, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
-    private readonly AzuraCastPingService _pingService = pingService;
+    private readonly IAzuraCastPingService _pingService = pingService;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotCheckPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotCheckPermissionsJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotCheckPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotCheckPermissionsJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
 
@@ -11,10 +12,10 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzzyBotCheckPermissionsJob(IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzzyBotCheckPermissionsJob(IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotCheckPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotCheckPermissionsJob.cs
@@ -5,15 +5,15 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzzyBotCheckPermissionsJob(DbActions dbActions, DiscordBotService botService) : IJob
+public sealed class AzzyBotCheckPermissionsJob(IDbActions dbActions, DiscordBotService botService) : IJob
 {
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotInactiveGuildJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotInactiveGuildJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotInactiveGuildJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotInactiveGuildJob.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Structs;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
@@ -16,10 +16,10 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzzyBotInactiveGuildJob(ILogger<AzzyBotInactiveGuildJob> logger, CoreService coreService, IDiscordBotService botService) : IJob
+public sealed class AzzyBotInactiveGuildJob(ILogger<AzzyBotInactiveGuildJob> logger, ICoreService coreService, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<AzzyBotInactiveGuildJob> _logger = logger;
-    private readonly CoreService _coreService = coreService;
+    private readonly ICoreService _coreService = coreService;
     private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotInactiveGuildJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotInactiveGuildJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities.Structs;
 using AzzyBot.Core.Logging;
@@ -15,11 +16,11 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzzyBotInactiveGuildJob(ILogger<AzzyBotInactiveGuildJob> logger, CoreService coreService, DiscordBotService botService) : IJob
+public sealed class AzzyBotInactiveGuildJob(ILogger<AzzyBotInactiveGuildJob> logger, CoreService coreService, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<AzzyBotInactiveGuildJob> _logger = logger;
     private readonly CoreService _coreService = coreService;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotUpdateCheckJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotUpdateCheckJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotUpdateCheckJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotUpdateCheckJob.cs
@@ -2,14 +2,16 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
+
 using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzzyBotUpdateCheckJob(DiscordBotService botService, UpdaterService updater) : IJob
+public sealed class AzzyBotUpdateCheckJob(DiscordBotService botService, IUpdaterService updater) : IJob
 {
     private readonly DiscordBotService _botService = botService;
-    private readonly UpdaterService _updater = updater;
+    private readonly IUpdaterService _updater = updater;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotUpdateCheckJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotUpdateCheckJob.cs
@@ -8,9 +8,9 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class AzzyBotUpdateCheckJob(DiscordBotService botService, IUpdaterService updater) : IJob
+public sealed class AzzyBotUpdateCheckJob(IDiscordBotService botService, IUpdaterService updater) : IJob
 {
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
     private readonly IUpdaterService _updater = updater;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/DatabaseCleaningJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/DatabaseCleaningJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Bot/Services/CronJobs/DatabaseCleaningJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/DatabaseCleaningJob.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus;
 using DSharpPlus.Entities;
@@ -12,9 +12,9 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class DatabaseCleaningJob(DbMaintenance dbMaintenance, DiscordBotService botService, DiscordClient discordClient) : IJob
+public sealed class DatabaseCleaningJob(IDbMaintenance dbMaintenance, DiscordBotService botService, DiscordClient discordClient) : IJob
 {
-    private readonly DbMaintenance _dbMaintenance = dbMaintenance;
+    private readonly IDbMaintenance _dbMaintenance = dbMaintenance;
     private readonly DiscordBotService _botService = botService;
     private readonly DiscordClient _discordClient = discordClient;
 

--- a/src/AzzyBot.Bot/Services/CronJobs/DatabaseCleaningJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/DatabaseCleaningJob.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus;
@@ -12,10 +13,10 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class DatabaseCleaningJob(IDbMaintenance dbMaintenance, DiscordBotService botService, DiscordClient discordClient) : IJob
+public sealed class DatabaseCleaningJob(IDbMaintenance dbMaintenance, IDiscordBotService botService, DiscordClient discordClient) : IJob
 {
     private readonly IDbMaintenance _dbMaintenance = dbMaintenance;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
     private readonly DiscordClient _discordClient = discordClient;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/LogfileCleaningJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/LogfileCleaningJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AzzyBot.Bot/Services/CronJobs/LogfileCleaningJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/LogfileCleaningJob.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Core.Logging;
 
 using Microsoft.Extensions.Logging;
@@ -13,10 +14,10 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class LogfileCleaningJob(ILogger<LogfileCleaningJob> logger, DiscordBotService botService) : IJob
+public sealed class LogfileCleaningJob(ILogger<LogfileCleaningJob> logger, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<LogfileCleaningJob> _logger = logger;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;

--- a/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Core.Logging;
@@ -21,11 +22,11 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class MusicStreamingPersistentNowPlayingJob(ILogger<MusicStreamingPersistentNowPlayingJob> logger, MusicStreamingService musicStreaming, IDbActions dbActions, DiscordBotService botService) : IJob
+public sealed class MusicStreamingPersistentNowPlayingJob(ILogger<MusicStreamingPersistentNowPlayingJob> logger, MusicStreamingService musicStreaming, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<MusicStreamingPersistentNowPlayingJob> _logger = logger;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
     private readonly MusicStreamingService _musicStreaming = musicStreaming;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)

--- a/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
-using AzzyBot.Bot.Services.Modules;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
@@ -22,12 +22,12 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class MusicStreamingPersistentNowPlayingJob(ILogger<MusicStreamingPersistentNowPlayingJob> logger, MusicStreamingService musicStreaming, IDbActions dbActions, IDiscordBotService botService) : IJob
+public sealed class MusicStreamingPersistentNowPlayingJob(ILogger<MusicStreamingPersistentNowPlayingJob> logger, IMusicStreamingService musicStreaming, IDbActions dbActions, IDiscordBotService botService) : IJob
 {
     private readonly ILogger<MusicStreamingPersistentNowPlayingJob> _logger = logger;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
-    private readonly MusicStreamingService _musicStreaming = musicStreaming;
+    private readonly IMusicStreamingService _musicStreaming = musicStreaming;
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
@@ -8,7 +8,7 @@ using AzzyBot.Bot.Services.Modules;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Entities;
 using DSharpPlus.Exceptions;
@@ -21,10 +21,10 @@ using NCronJob;
 
 namespace AzzyBot.Bot.Services.CronJobs;
 
-public sealed class MusicStreamingPersistentNowPlayingJob(ILogger<MusicStreamingPersistentNowPlayingJob> logger, MusicStreamingService musicStreaming, DbActions dbActions, DiscordBotService botService) : IJob
+public sealed class MusicStreamingPersistentNowPlayingJob(ILogger<MusicStreamingPersistentNowPlayingJob> logger, MusicStreamingService musicStreaming, IDbActions dbActions, DiscordBotService botService) : IJob
 {
     private readonly ILogger<MusicStreamingPersistentNowPlayingJob> _logger = logger;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
     private readonly MusicStreamingService _musicStreaming = musicStreaming;
 

--- a/src/AzzyBot.Bot/Services/DiscordBotService.cs
+++ b/src/AzzyBot.Bot/Services/DiscordBotService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/AzzyBot.Bot/Services/DiscordBotService.cs
+++ b/src/AzzyBot.Bot/Services/DiscordBotService.cs
@@ -432,8 +432,18 @@ public sealed class DiscordBotService(ILogger<DiscordBotService> logger, IOption
             activityType = DiscordActivityType.Playing;
         }
 
+        string[] allowedStreamingHosts = ["twitch", "youtube"];
+        bool isAllowedStreamingHost = url is not null && Array.Exists(allowedStreamingHosts, h => url.Host.Contains(h, StringComparison.OrdinalIgnoreCase));
+
+        if (activityType is DiscordActivityType.Streaming && !isAllowedStreamingHost)
+        {
+            _logger.BotStatusStreamingInvalidUrl();
+            activityType = DiscordActivityType.Playing;
+        }
+
         DiscordActivity activity = new(doing, activityType);
-        if (activityType is DiscordActivityType.Streaming && url is not null && (url.Host.Contains("twitch", StringComparison.OrdinalIgnoreCase) || url.Host.Contains("youtube", StringComparison.OrdinalIgnoreCase)))
+
+        if (activityType is DiscordActivityType.Streaming && isAllowedStreamingHost && url is not null)
         {
             activity.StreamUrl = url.OriginalString;
             _logger.BotStatusStreamUrlSet(url.OriginalString);

--- a/src/AzzyBot.Bot/Services/DiscordBotService.cs
+++ b/src/AzzyBot.Bot/Services/DiscordBotService.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Commands.Checks;
 using AzzyBot.Bot.Resources;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Helpers;
@@ -33,7 +34,7 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class DiscordBotService(ILogger<DiscordBotService> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordClient client)
+public sealed class DiscordBotService(ILogger<DiscordBotService> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordClient client) : IDiscordBotService
 {
     private readonly ILogger<DiscordBotService> _logger = logger;
     private readonly AzzyBotSettings _settings = settings.Value;
@@ -412,21 +413,50 @@ public sealed class DiscordBotService(ILogger<DiscordBotService> logger, IOption
         await _client.UpdateStatusAsync(activity, newStatus);
     }
 
-    public static DiscordActivity SetBotStatusActivity(int type, string doing, Uri? url)
+    public DiscordActivity SetBotStatusActivity(int type, string doing, Uri? url)
     {
-        DiscordActivityType activityType = (Enum.IsDefined(typeof(DiscordActivityType), type)) ? (DiscordActivityType)type : DiscordActivityType.ListeningTo;
+        DiscordActivityType activityType;
+        if (Enum.IsDefined(typeof(DiscordActivityType), type))
+        {
+            activityType = (DiscordActivityType)type;
+        }
+        else
+        {
+            _logger.BotStatusActivityTypeNotDefined(type);
+            activityType = DiscordActivityType.ListeningTo;
+        }
+
         if (activityType is DiscordActivityType.Streaming && url is null)
+        {
+            _logger.BotStatusStreamingRequiresUrl();
             activityType = DiscordActivityType.Playing;
+        }
 
         DiscordActivity activity = new(doing, activityType);
         if (activityType is DiscordActivityType.Streaming && url is not null && (url.Host.Contains("twitch", StringComparison.OrdinalIgnoreCase) || url.Host.Contains("youtube", StringComparison.OrdinalIgnoreCase)))
+        {
             activity.StreamUrl = url.OriginalString;
+            _logger.BotStatusStreamUrlSet(url.OriginalString);
+        }
+
+        _logger.BotStatusActivitySet(activityType.ToString(), doing);
 
         return activity;
     }
 
-    public static DiscordUserStatus SetBotStatusUserStatus(int status)
-        => (Enum.IsDefined(typeof(DiscordUserStatus), status)) ? (DiscordUserStatus)status : DiscordUserStatus.Online;
+    public DiscordUserStatus SetBotStatusUserStatus(int status)
+    {
+        if (!Enum.IsDefined(typeof(DiscordUserStatus), status))
+        {
+            _logger.BotStatusUserStatusNotDefined(status);
+            return DiscordUserStatus.Online;
+        }
+
+        DiscordUserStatus userStatus = (DiscordUserStatus)status;
+        _logger.BotStatusUserStatusSet(userStatus.ToString());
+
+        return userStatus;
+    }
 
     private static async Task<DiscordMessage?> AcknowledgeExceptionAsync(SlashCommandContext ctx)
     {

--- a/src/AzzyBot.Bot/Services/DiscordBotService.cs
+++ b/src/AzzyBot.Bot/Services/DiscordBotService.cs
@@ -121,7 +121,7 @@ public sealed class DiscordBotService(ILogger<DiscordBotService> logger, IOption
             }
         }
 
-        await _dbActions.UpdateGuildAsync(guildEntity.UniqueId, true);
+        await _dbActions.UpdateGuildAsync(guildEntity.UniqueId, updateLastPermissionCheck: true);
 
         await CheckPermissionsCoreAsync(guild, member, channels);
     }

--- a/src/AzzyBot.Bot/Services/DiscordBotService.cs
+++ b/src/AzzyBot.Bot/Services/DiscordBotService.cs
@@ -426,24 +426,26 @@ public sealed class DiscordBotService(ILogger<DiscordBotService> logger, IOption
             activityType = DiscordActivityType.ListeningTo;
         }
 
-        if (activityType is DiscordActivityType.Streaming && url is null)
-        {
-            _logger.BotStatusStreamingRequiresUrl();
-            activityType = DiscordActivityType.Playing;
-        }
-
         string[] allowedStreamingHosts = ["twitch", "youtube"];
-        bool isAllowedStreamingHost = url is not null && Array.Exists(allowedStreamingHosts, h => url.Host.Contains(h, StringComparison.OrdinalIgnoreCase));
+        bool isValidStreamingUrl = url is not null && Array.Exists(allowedStreamingHosts, h => url.Host.Contains(h, StringComparison.OrdinalIgnoreCase));
 
-        if (activityType is DiscordActivityType.Streaming && !isAllowedStreamingHost)
+        if (activityType is DiscordActivityType.Streaming && !isValidStreamingUrl)
         {
-            _logger.BotStatusStreamingInvalidUrl();
+            if (url is null)
+            {
+                _logger.BotStatusStreamingRequiresUrl();
+            }
+            else
+            {
+                _logger.BotStatusStreamingInvalidUrl();
+            }
+
             activityType = DiscordActivityType.Playing;
         }
 
         DiscordActivity activity = new(doing, activityType);
 
-        if (activityType is DiscordActivityType.Streaming && isAllowedStreamingHost && url is not null)
+        if (activityType is DiscordActivityType.Streaming && url is not null)
         {
             activity.StreamUrl = url.OriginalString;
             _logger.BotStatusStreamUrlSet(url.OriginalString);

--- a/src/AzzyBot.Bot/Services/DiscordBotService.cs
+++ b/src/AzzyBot.Bot/Services/DiscordBotService.cs
@@ -17,7 +17,7 @@ using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
 using AzzyBot.Core.Utilities.Helpers;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus;
 using DSharpPlus.Commands.ContextChecks;
@@ -33,11 +33,11 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class DiscordBotService(ILogger<DiscordBotService> logger, IOptions<AzzyBotSettings> settings, DbActions dbActions, DiscordClient client)
+public sealed class DiscordBotService(ILogger<DiscordBotService> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordClient client)
 {
     private readonly ILogger<DiscordBotService> _logger = logger;
     private readonly AzzyBotSettings _settings = settings.Value;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordClient _client = client;
 
     private bool CheckIfClientIsConnected

--- a/src/AzzyBot.Bot/Services/DiscordBotServiceHost.cs
+++ b/src/AzzyBot.Bot/Services/DiscordBotServiceHost.cs
@@ -1,30 +1,31 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Core.Logging;
 
 using DSharpPlus;
 using DSharpPlus.Entities;
 
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class DiscordBotServiceHost(ILogger<DiscordBotServiceHost> logger, IOptions<DiscordStatusSettings> settings, DiscordClient client) : IHostedService
+public sealed class DiscordBotServiceHost(ILogger<DiscordBotServiceHost> logger, IOptions<DiscordStatusSettings> settings, IDiscordBotService botService, DiscordClient client) : IDiscordBotServiceHost
 {
     private readonly ILogger<DiscordBotServiceHost> _logger = logger;
     private readonly DiscordStatusSettings _settings = settings.Value;
+    private readonly IDiscordBotService _botService = botService;
     private readonly DiscordClient _client = client;
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        DiscordActivity activity = DiscordBotService.SetBotStatusActivity(_settings.Activity, _settings.Doing, _settings.StreamUrl);
-        DiscordUserStatus status = DiscordBotService.SetBotStatusUserStatus(_settings.Status);
+        DiscordActivity activity = _botService.SetBotStatusActivity(_settings.Activity, _settings.Doing, _settings.StreamUrl);
+        DiscordUserStatus status = _botService.SetBotStatusUserStatus(_settings.Status);
 
         await _client.ConnectAsync(activity, status);
 

--- a/src/AzzyBot.Bot/Services/DiscordBotServiceHost.cs
+++ b/src/AzzyBot.Bot/Services/DiscordBotServiceHost.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading;
+using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordCommandsErrorHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordCommandsErrorHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Core.Logging;
 
 using DSharpPlus.Commands;
@@ -13,10 +14,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.DiscordEvents;
 
-public sealed class DiscordCommandsErrorHandler(ILogger<DiscordCommandsErrorHandler> logger, DiscordBotService botService)
+public sealed class DiscordCommandsErrorHandler(ILogger<DiscordCommandsErrorHandler> logger, IDiscordBotService botService)
 {
     private readonly ILogger<DiscordCommandsErrorHandler> _logger = logger;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task CommandErroredAsync(CommandsExtension c, CommandErroredEventArgs e)
     {

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordCommandsErrorHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordCommandsErrorHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordErrorsHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordErrorsHandler.cs
@@ -1,14 +1,16 @@
 ﻿using System;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
+
 using DSharpPlus;
 using DSharpPlus.Exceptions;
 
 namespace AzzyBot.Bot.Services.DiscordEvents;
 
-public sealed class DiscordErrorsHandler(DiscordBotService botService) : IClientErrorHandler
+public sealed class DiscordErrorsHandler(IDiscordBotService botService) : IClientErrorHandler
 {
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async ValueTask HandleEventHandlerError(string name, Exception exception, Delegate invokedDelegate, object sender, object args)
     {

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordErrorsHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordErrorsHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
@@ -7,7 +7,7 @@ using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus;
 using DSharpPlus.Entities;
@@ -18,13 +18,13 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.DiscordEvents;
 
-public sealed class DiscordGuildsHandler(ILogger<DiscordGuildsHandler> logger, IOptions<AzzyBotSettings> settings, CronJobManager cron, DbActions dbActions, DiscordBotService botService)
+public sealed class DiscordGuildsHandler(ILogger<DiscordGuildsHandler> logger, IOptions<AzzyBotSettings> settings, CronJobManager cron, IDbActions dbActions, DiscordBotService botService)
     : IEventHandler<GuildCreatedEventArgs>, IEventHandler<GuildDeletedEventArgs>, IEventHandler<GuildDownloadCompletedEventArgs>
 {
     private readonly ILogger<DiscordGuildsHandler> _logger = logger;
     private readonly AzzyBotSettings _settings = settings.Value;
     private readonly CronJobManager _cron = cron;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task HandleEventAsync(DiscordClient sender, GuildCreatedEventArgs eventArgs)

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Core.Logging;
@@ -18,12 +19,12 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.DiscordEvents;
 
-public sealed class DiscordGuildsHandler(ILogger<DiscordGuildsHandler> logger, IOptions<AzzyBotSettings> settings, CronJobManager cron, IDbActions dbActions, DiscordBotService botService)
+public sealed class DiscordGuildsHandler(ILogger<DiscordGuildsHandler> logger, IOptions<AzzyBotSettings> settings, ICronJobManager cron, IDbActions dbActions, DiscordBotService botService)
     : IEventHandler<GuildCreatedEventArgs>, IEventHandler<GuildDeletedEventArgs>, IEventHandler<GuildDownloadCompletedEventArgs>
 {
     private readonly ILogger<DiscordGuildsHandler> _logger = logger;
     private readonly AzzyBotSettings _settings = settings.Value;
-    private readonly CronJobManager _cron = cron;
+    private readonly ICronJobManager _cron = cron;
     private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
@@ -19,14 +19,14 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.DiscordEvents;
 
-public sealed class DiscordGuildsHandler(ILogger<DiscordGuildsHandler> logger, IOptions<AzzyBotSettings> settings, ICronJobManager cron, IDbActions dbActions, DiscordBotService botService)
+public sealed class DiscordGuildsHandler(ILogger<DiscordGuildsHandler> logger, IOptions<AzzyBotSettings> settings, ICronJobManager cron, IDbActions dbActions, IDiscordBotService botService)
     : IEventHandler<GuildCreatedEventArgs>, IEventHandler<GuildDeletedEventArgs>, IEventHandler<GuildDownloadCompletedEventArgs>
 {
     private readonly ILogger<DiscordGuildsHandler> _logger = logger;
     private readonly AzzyBotSettings _settings = settings.Value;
     private readonly ICronJobManager _cron = cron;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task HandleEventAsync(DiscordClient sender, GuildCreatedEventArgs eventArgs)
     {

--- a/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
+++ b/src/AzzyBot.Bot/Services/DiscordEvents/DiscordGuildsHandler.cs
@@ -107,7 +107,7 @@ public sealed class DiscordGuildsHandler(ILogger<DiscordGuildsHandler> logger, I
         // Start the Guild Reminder Check
         _cron.RunAzzyBotInactiveGuildJob();
         azzy.LastGuildReminderCheck = DateTimeOffset.UtcNow;
-        await _dbActions.UpdateAzzyBotAsync(lastGuildReminder: true);
+        await _dbActions.UpdateAzzyBotAsync(updateLastGuildReminder: true);
     }
 
     private async Task GuildCreatedHelperAsync(IEnumerable<DiscordGuild> guilds)

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -1,4 +1,4 @@
-﻿using AzzyBot.Bot.Utilities.Records.AzuraCast;
+using AzzyBot.Bot.Utilities.Records.AzuraCast;
 
 using NCronJob;
 

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -1,0 +1,11 @@
+﻿using AzzyBot.Bot.Utilities.Records.AzuraCast;
+
+using NCronJob;
+
+namespace AzzyBot.Bot.Services.Interfaces;
+
+public interface ICronJobManager : IExceptionHandler
+{
+    void RunAzzyBotInactiveGuildJob();
+    void RunAzuraRequestJob(AzuraCustomQueueItemRecord record);
+}

--- a/src/AzzyBot.Bot/Services/Interfaces/IDiscordBotService.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IDiscordBotService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/AzzyBot.Bot/Services/Interfaces/IDiscordBotService.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IDiscordBotService.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AzzyBot.Data.Entities;
+
+using DSharpPlus.Commands.Exceptions;
+using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Entities;
+
+namespace AzzyBot.Bot.Services.Interfaces;
+
+public interface IDiscordBotService
+{
+    Task<bool> CheckChannelPermissionsAsync(DiscordMember member, ulong channelId, DiscordPermissions permissions);
+    Task CheckPermissionsAsync(DiscordGuild guild, ulong[] channelIds);
+    Task CheckPermissionsAsync(GuildEntity guildEntity);
+    Task CheckPermissionsAsync(IReadOnlyList<GuildEntity> guilds);
+    Task<DiscordChannel?> GetDiscordChannelAsync(ulong channelId);
+    DiscordGuild? GetDiscordGuild(ulong guildId = 0);
+    IReadOnlyDictionary<ulong, DiscordGuild> GetDiscordGuilds { get; }
+    Task<DiscordMember?> GetDiscordMemberAsync(ulong guildId, ulong userId = 0);
+    Task LogExceptionAsync(Exception ex, DateTimeOffset timestamp, SlashCommandContext? ctx = null, string? info = null);
+    Task RespondToChecksExceptionAsync(ChecksFailedException ex, SlashCommandContext context);
+    Task<bool> SendMessageAsync(ulong channelId, string? content = null, IReadOnlyList<DiscordEmbed>? embeds = null, IReadOnlyList<string>? filePaths = null, IMention[]? mentions = null);
+    Task<bool> SendMessageToOwnerAsync(ulong guildId, string? content = null, IReadOnlyList<DiscordEmbed>? embeds = null, IReadOnlyList<string>? filePaths = null);
+    Task SetBotStatusAsync(int status, int type, string doing, Uri? url = null, bool reset = false);
+    DiscordActivity SetBotStatusActivity(int type, string doing, Uri? url);
+    DiscordUserStatus SetBotStatusUserStatus(int status);
+}

--- a/src/AzzyBot.Bot/Services/Interfaces/IDiscordBotServiceHost.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IDiscordBotServiceHost.cs
@@ -1,0 +1,5 @@
+﻿using Microsoft.Extensions.Hosting;
+
+namespace AzzyBot.Bot.Services.Interfaces;
+
+public interface IDiscordBotServiceHost : IHostedService;

--- a/src/AzzyBot.Bot/Services/Interfaces/IDiscordBotServiceHost.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IDiscordBotServiceHost.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting;
 
 namespace AzzyBot.Bot.Services.Interfaces;
 

--- a/src/AzzyBot.Bot/Services/Interfaces/IUpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IUpdaterService.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace AzzyBot.Bot.Services.Interfaces;
+
+public interface IUpdaterService
+{
+    IReadOnlyDictionary<string, string> GitHubHeaders { get; }
+    Task CheckForAzzyUpdatesAsync();
+}

--- a/src/AzzyBot.Bot/Services/Interfaces/IUpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IUpdaterService.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace AzzyBot.Bot.Services.Interfaces;

--- a/src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AzzyBot.Bot.Utilities.Records;
+
+namespace AzzyBot.Bot.Services.Interfaces;
+
+public interface IWebRequestService
+{
+    Task<IReadOnlyList<bool>> CheckForApiPermissionsAsync(IReadOnlyList<Uri> urls, IReadOnlyDictionary<string, string> headers);
+    Task DeleteAsync(Uri uri, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);
+    Task<string> DownloadAsync(Uri url, string downloadPath, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool acceptImage = false, bool noCache = true);
+    Task<AzzyIpAddressRecord> GetIpAddressesAsync();
+    Task<long> GetPingAsync(Uri uri);
+    Task<string?> GetWebAsync(Uri url, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true, bool noLogging = false);
+    Task PostWebAsync(Uri url, string? content = null, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);
+    Task PutWebAsync(Uri url, string? content = null, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);
+    Task<string?> UploadAsync(Uri url, string file, string fileName, string filePath, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);
+}

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
@@ -23,11 +24,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, DiscordBotService botService, WebRequestService webService)
+public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, DiscordBotService botService, IWebRequestService webService)
 {
     private readonly ILogger<AzuraCastApiService> _logger = logger;
     private readonly DiscordBotService _botService = botService;
-    private readonly WebRequestService _webService = webService;
+    private readonly IWebRequestService _webService = webService;
     public const string AzuraCastPermissionsWiki = "Please review your [permission](https://github.com/Sella-GH/AzzyBot/wiki/AzuraCast-API-Key-required-permissions) set.";
 
     public string FilePath { get; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Modules", "AzuraCast", "Files");

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -24,10 +24,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, DiscordBotService botService, IWebRequestService webService)
+public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDiscordBotService botService, IWebRequestService webService)
 {
     private readonly ILogger<AzuraCastApiService> _logger = logger;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
     private readonly IWebRequestService _webService = webService;
     public const string AzuraCastPermissionsWiki = "Please review your [permission](https://github.com/Sella-GH/AzzyBot/wiki/AzuraCast-API-Key-required-permissions) set.";
 

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Serialization.Metadata;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
@@ -24,13 +25,13 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDiscordBotService botService, IWebRequestService webService)
+public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDiscordBotService botService, IWebRequestService webService) : IAzuraCastApiService
 {
     private readonly ILogger<AzuraCastApiService> _logger = logger;
     private readonly IDiscordBotService _botService = botService;
     private readonly IWebRequestService _webService = webService;
-    public const string AzuraCastPermissionsWiki = "Please review your [permission](https://github.com/Sella-GH/AzzyBot/wiki/AzuraCast-API-Key-required-permissions) set.";
 
+    public string AzuraCastPermissionsWiki { get; } = "Please review your [permission](https://github.com/Sella-GH/AzzyBot/wiki/AzuraCast-API-Key-required-permissions) set.";
     public string FilePath { get; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Modules", "AzuraCast", "Files");
 
     private static Dictionary<string, string> CreateHeader(string apiKey)
@@ -546,12 +547,12 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDi
         return GetFromApiAsync<AzuraAdminStationConfigRecord>(baseUrl, endpoint, JsonSourceGen.Default.AzuraAdminStationConfigRecord, CreateHeader(apiKey));
     }
 
-    public Task<IEnumerable<AzuraStationHistoryItemRecord>?> GetStationHistoryAsync(Uri baseUrl, string apiKey, int stationId, in DateTimeOffset start, in DateTimeOffset end)
+    public Task<IEnumerable<AzuraStationHistoryItemRecord>?> GetStationHistoryAsync(Uri baseUrl, string apiKey, int stationId, in DateTimeOffset startHistory, in DateTimeOffset endHistory)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stationId);
 
-        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.History}?{AzuraApiFilters.Start}={start:yyyy-MM-dd}&{AzuraApiFilters.End}={end:yyyy-MM-dd}";
+        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.History}?{AzuraApiFilters.Start}={startHistory:yyyy-MM-dd}&{AzuraApiFilters.End}={endHistory:yyyy-MM-dd}";
 
         return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraStationHistoryItemRecord, CreateHeader(apiKey));
     }

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -31,7 +31,7 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDi
     private readonly IDiscordBotService _botService = botService;
     private readonly IWebRequestService _webService = webService;
 
-    public string AzuraCastPermissionsWiki { get; } = "Please review your [permission](https://github.com/Sella-GH/AzzyBot/wiki/AzuraCast-API-Key-required-permissions) set.";
+    public string AzuraCastPermissionsWiki { get; } = "Please review your [permissions](https://github.com/Sella-GH/AzzyBot/wiki/AzuraCast-API-Key-required-permissions) set.";
     public string FilePath { get; } = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Modules", "AzuraCast", "Files");
 
     private static Dictionary<string, string> CreateHeader(string apiKey)

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -20,12 +21,12 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, AzuraCastApiService azuraCast, IDbActions dbActions, DiscordBotService discordBotService)
+public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, AzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService)
 {
     private readonly ILogger<AzuraCastFileService> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = discordBotService;
+    private readonly IDiscordBotService _botService = discordBotService;
 
     public async Task CheckForFileChangesAsync(AzuraCastStationEntity station)
     {

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
@@ -22,7 +22,7 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService)
+public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService) : IAzuraCastFileService
 {
     private readonly ILogger<AzuraCastFileService> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCast;

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
@@ -69,7 +69,7 @@ public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, I
         List<AzuraFilesRecord> addedFiles = [.. onlineHashSet.Except(localHashSet)];
         List<AzuraFilesRecord> removedFiles = [.. localHashSet.Except(onlineHashSet)];
         bool filesChanged = addedFiles.Count is not 0 || removedFiles.Count is not 0;
-        await _dbActions.UpdateAzuraCastStationChecksAsync(station.AzuraCast.Guild.UniqueId, station.StationId, lastFileChangesCheck: true);
+        await _dbActions.UpdateAzuraCastStationChecksAsync(station.AzuraCast.Guild.UniqueId, station.StationId, updateLastFileChangesCheck: true);
         if (!filesChanged)
             return;
 

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
@@ -12,7 +12,7 @@ using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Entities;
 
@@ -20,11 +20,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, AzuraCastApiService azuraCast, DbActions dbActions, DiscordBotService discordBotService)
+public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, AzuraCastApiService azuraCast, IDbActions dbActions, DiscordBotService discordBotService)
 {
     private readonly ILogger<AzuraCastFileService> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = discordBotService;
 
     public async Task CheckForFileChangesAsync(AzuraCastStationEntity station)

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastFileService.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
@@ -21,10 +22,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, AzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService)
+public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService)
 {
     private readonly ILogger<AzuraCastFileService> _logger = logger;
-    private readonly AzuraCastApiService _azuraCast = azuraCast;
+    private readonly IAzuraCastApiService _azuraCast = azuraCast;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = discordBotService;
 
@@ -41,14 +42,14 @@ public sealed class AzuraCastFileService(ILogger<AzuraCastFileService> logger, A
         AzuraStationRecord? azuraStation = await _azuraCast.GetStationAsync(baseUrl, apiKey, station.StationId);
         if (azuraStation is null)
         {
-            await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** endpoint on station ID: {station.StationId}.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+            await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station** endpoint on station ID: {station.StationId}.\n{_azuraCast.AzuraCastPermissionsWiki}");
             return;
         }
 
         IEnumerable<AzuraFilesRecord>? onlineFiles = await _azuraCast.GetFilesOnlineBasicAsync(baseUrl, apiKey, station.StationId);
         if (onlineFiles is null)
         {
-            await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station *{azuraStation.Name}* (ID: {station.StationId}).\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+            await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **files** endpoint on station *{azuraStation.Name}* (ID: {station.StationId}).\n{_azuraCast.AzuraCastPermissionsWiki}");
             return;
         }
 

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
@@ -70,6 +70,6 @@ public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, I
             _logger.BackgroundServiceInstanceStatus(azuraCast.GuildId, azuraCast.Id, "unkown or offline");
         }
 
-        await _dbActions.UpdateAzuraCastChecksAsync(azuraCast.Guild.UniqueId, lastServerStatusCheck: true);
+        await _dbActions.UpdateAzuraCastChecksAsync(azuraCast.Guild.UniqueId, updateLastServerStatusCheck: true);
     }
 }

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
@@ -4,6 +4,7 @@ using System.Security.Authentication;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
@@ -14,10 +15,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, AzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService)
+public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService)
 {
     private readonly ILogger<AzuraCastPingService> _logger = logger;
-    private readonly AzuraCastApiService _azuraCast = azuraCast;
+    private readonly IAzuraCastApiService _azuraCast = azuraCast;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = discordBotService;
 

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService)
+public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, IAzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService) : IAzuraCastPingService
 {
     private readonly ILogger<AzuraCastPingService> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCast;

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
@@ -67,7 +67,7 @@ public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, I
         }
         else
         {
-            _logger.BackgroundServiceInstanceStatus(azuraCast.GuildId, azuraCast.Id, "unkown or offline");
+            _logger.BackgroundServiceInstanceStatus(azuraCast.GuildId, azuraCast.Id, "unknown or offline");
         }
 
         await _dbActions.UpdateAzuraCastChecksAsync(azuraCast.Guild.UniqueId, updateLastServerStatusCheck: true);

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Security.Authentication;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
@@ -13,12 +14,12 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, AzuraCastApiService azuraCast, IDbActions dbActions, DiscordBotService discordBotService)
+public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, AzuraCastApiService azuraCast, IDbActions dbActions, IDiscordBotService discordBotService)
 {
     private readonly ILogger<AzuraCastPingService> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = discordBotService;
+    private readonly IDiscordBotService _botService = discordBotService;
 
     public async Task PingInstanceAsync(AzuraCastEntity azuraCast)
     {

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastPingService.cs
@@ -7,17 +7,17 @@ using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, AzuraCastApiService azuraCast, DbActions dbActions, DiscordBotService discordBotService)
+public sealed class AzuraCastPingService(ILogger<AzuraCastPingService> logger, AzuraCastApiService azuraCast, IDbActions dbActions, DiscordBotService discordBotService)
 {
     private readonly ILogger<AzuraCastPingService> _logger = logger;
     private readonly AzuraCastApiService _azuraCast = azuraCast;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = discordBotService;
 
     public async Task PingInstanceAsync(AzuraCastEntity azuraCast)

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
@@ -16,11 +16,11 @@ using DSharpPlus.Entities;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, IDbActions dbActions, DiscordBotService botService, IUpdaterService updaterService, IWebRequestService webRequest)
+public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, IDbActions dbActions, IDiscordBotService botService, IUpdaterService updaterService, IWebRequestService webRequest)
 {
     private readonly AzuraCastApiService _azuraCastApiService = azuraCastApiService;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
     private readonly IUpdaterService _updaterService = updaterService;
     private readonly IWebRequestService _webRequest = webRequest;
 

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using AzzyBot.Bot.Resources;
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Utilities;
@@ -16,9 +17,9 @@ using DSharpPlus.Entities;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, IDbActions dbActions, IDiscordBotService botService, IUpdaterService updaterService, IWebRequestService webRequest)
+public sealed class AzuraCastUpdateService(IAzuraCastApiService azuraCastApiService, IDbActions dbActions, IDiscordBotService botService, IUpdaterService updaterService, IWebRequestService webRequest)
 {
-    private readonly AzuraCastApiService _azuraCastApiService = azuraCastApiService;
+    private readonly IAzuraCastApiService _azuraCastApiService = azuraCastApiService;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
     private readonly IUpdaterService _updaterService = updaterService;
@@ -37,7 +38,7 @@ public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiServi
             body = await _azuraCastApiService.GetUpdatesAsync(baseUrl, apiKey);
             if (string.IsNullOrEmpty(body))
             {
-                await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative updates** endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative updates** endpoint.\n{_azuraCastApiService.AzuraCastPermissionsWiki}");
                 return;
             }
         }
@@ -67,7 +68,7 @@ public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiServi
 
         if (update is null)
         {
-            await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative updates** endpoint.\n{AzuraCastApiService.AzuraCastPermissionsWiki}");
+            await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **administrative updates** endpoint.\n{_azuraCastApiService.AzuraCastPermissionsWiki}");
             return;
         }
 

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
@@ -4,8 +4,10 @@ using System.Text.Json;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Resources;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
+using AzzyBot.Core.Utilities;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
@@ -14,12 +16,12 @@ using DSharpPlus.Entities;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, IDbActions dbActions, DiscordBotService botService, UpdaterService updaterService, WebRequestService webRequest)
+public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, IDbActions dbActions, DiscordBotService botService, IUpdaterService updaterService, WebRequestService webRequest)
 {
     private readonly AzuraCastApiService _azuraCastApiService = azuraCastApiService;
     private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
-    private readonly UpdaterService _updaterService = updaterService;
+    private readonly IUpdaterService _updaterService = updaterService;
     private readonly WebRequestService _webRequest = webRequest;
 
     public async Task CheckForAzuraCastUpdatesAsync(AzuraCastEntity azuraCast, bool forced = false)
@@ -76,7 +78,7 @@ public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiServi
         }
 
         AzuraCastChecksEntity checks = azuraCast.Checks;
-        if (!forced && !UpdaterService.CheckUpdateNotification(checks.UpdateNotificationCounter, checks.LastUpdateCheck))
+        if (!forced && !Misc.CheckUpdateNotification(checks.UpdateNotificationCounter, checks.LastUpdateCheck))
             return;
 
         await _dbActions.UpdateAzuraCastChecksAsync(azuraCast.Guild.UniqueId, updateNotificationCounter: checks.UpdateNotificationCounter + 1, lastUpdateCheck: true);

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
@@ -17,7 +17,7 @@ using DSharpPlus.Entities;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastUpdateService(IAzuraCastApiService azuraCastApiService, IDbActions dbActions, IDiscordBotService botService, IUpdaterService updaterService, IWebRequestService webRequest)
+public sealed class AzuraCastUpdateService(IAzuraCastApiService azuraCastApiService, IDbActions dbActions, IDiscordBotService botService, IUpdaterService updaterService, IWebRequestService webRequest) : IAzuraCastUpdateService
 {
     private readonly IAzuraCastApiService _azuraCastApiService = azuraCastApiService;
     private readonly IDbActions _dbActions = dbActions;

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
@@ -8,16 +8,16 @@ using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Entities;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, DbActions dbActions, DiscordBotService botService, UpdaterService updaterService, WebRequestService webRequest)
+public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, IDbActions dbActions, DiscordBotService botService, UpdaterService updaterService, WebRequestService webRequest)
 {
     private readonly AzuraCastApiService _azuraCastApiService = azuraCastApiService;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
     private readonly UpdaterService _updaterService = updaterService;
     private readonly WebRequestService _webRequest = webRequest;

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
@@ -74,7 +74,7 @@ public sealed class AzuraCastUpdateService(IAzuraCastApiService azuraCastApiServ
 
         if (!update.NeedsReleaseUpdate && !update.NeedsRollingUpdate)
         {
-            await _dbActions.UpdateAzuraCastChecksAsync(azuraCast.Guild.UniqueId, updateNotificationCounter: 0, lastUpdateCheck: true);
+            await _dbActions.UpdateAzuraCastChecksAsync(azuraCast.Guild.UniqueId, updateNotificationCounter: 0, updateLastUpdateCheck: true);
             return;
         }
 
@@ -82,7 +82,7 @@ public sealed class AzuraCastUpdateService(IAzuraCastApiService azuraCastApiServ
         if (!forced && !Misc.CheckUpdateNotification(checks.UpdateNotificationCounter, checks.LastUpdateCheck))
             return;
 
-        await _dbActions.UpdateAzuraCastChecksAsync(azuraCast.Guild.UniqueId, updateNotificationCounter: checks.UpdateNotificationCounter + 1, lastUpdateCheck: true);
+        await _dbActions.UpdateAzuraCastChecksAsync(azuraCast.Guild.UniqueId, updateNotificationCounter: checks.UpdateNotificationCounter + 1, updateLastUpdateCheck: true);
 
         List<DiscordEmbed> embeds = new(2)
         {

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastUpdateService.cs
@@ -16,13 +16,13 @@ using DSharpPlus.Entities;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, IDbActions dbActions, DiscordBotService botService, IUpdaterService updaterService, WebRequestService webRequest)
+public sealed class AzuraCastUpdateService(AzuraCastApiService azuraCastApiService, IDbActions dbActions, DiscordBotService botService, IUpdaterService updaterService, IWebRequestService webRequest)
 {
     private readonly AzuraCastApiService _azuraCastApiService = azuraCastApiService;
     private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
     private readonly IUpdaterService _updaterService = updaterService;
-    private readonly WebRequestService _webRequest = webRequest;
+    private readonly IWebRequestService _webRequest = webRequest;
 
     public async Task CheckForAzuraCastUpdatesAsync(AzuraCastEntity azuraCast, bool forced = false)
     {

--- a/src/AzzyBot.Bot/Services/Modules/CoreService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/CoreService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;

--- a/src/AzzyBot.Bot/Services/Modules/CoreService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/CoreService.cs
@@ -54,7 +54,7 @@ public sealed class CoreService(ILogger<CoreService> logger, IOptions<AzzyBotSet
             victims.Add(guild, guildStruct);
         }
 
-        await _dbActions.UpdateAzzyBotAsync(lastGuildReminder: true);
+        await _dbActions.UpdateAzzyBotAsync(updateLastGuildReminder: true);
 
         return victims;
     }

--- a/src/AzzyBot.Bot/Services/Modules/CoreService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/CoreService.cs
@@ -11,7 +11,7 @@ using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Bot.Utilities.Structs;
 using AzzyBot.Core.Logging;
 using AzzyBot.Data.Entities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Entities;
 
@@ -20,11 +20,11 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class CoreService(ILogger<CoreService> logger, IOptions<AzzyBotSettings> settings, DbActions dbActions, DiscordBotService botService)
+public sealed class CoreService(ILogger<CoreService> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordBotService botService)
 {
     private readonly ILogger<CoreService> _logger = logger;
     private readonly AzzyBotSettings _settings = settings.Value;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
 
     public async Task<IReadOnlyDictionary<GuildEntity, AzzyInactiveGuildStruct>> CheckUnusedGuildsAsync()

--- a/src/AzzyBot.Bot/Services/Modules/CoreService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/CoreService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Helpers;
@@ -20,12 +21,12 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class CoreService(ILogger<CoreService> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, DiscordBotService botService)
+public sealed class CoreService(ILogger<CoreService> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, IDiscordBotService botService)
 {
     private readonly ILogger<CoreService> _logger = logger;
     private readonly AzzyBotSettings _settings = settings.Value;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public async Task<IReadOnlyDictionary<GuildEntity, AzzyInactiveGuildStruct>> CheckUnusedGuildsAsync()
     {

--- a/src/AzzyBot.Bot/Services/Modules/CoreService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/CoreService.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Helpers;
@@ -21,7 +22,7 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class CoreService(ILogger<CoreService> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, IDiscordBotService botService)
+public sealed class CoreService(ILogger<CoreService> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, IDiscordBotService botService) : ICoreService
 {
     private readonly ILogger<CoreService> _logger = logger;
     private readonly AzzyBotSettings _settings = settings.Value;

--- a/src/AzzyBot.Bot/Services/Modules/CoreServiceHost.cs
+++ b/src/AzzyBot.Bot/Services/Modules/CoreServiceHost.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/AzzyBot.Bot/Services/Modules/CoreServiceHost.cs
+++ b/src/AzzyBot.Bot/Services/Modules/CoreServiceHost.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Core.Logging;
@@ -16,13 +17,12 @@ using AzzyBot.Data.Services;
 using AzzyBot.Data.Settings;
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class CoreServiceHost(ILogger<CoreServiceHost> logger, IOptions<AzzyBotSettings> azzySettings, IOptions<DatabaseSettings> dbSettings, IOptions<DiscordStatusSettings> discordSettings, IOptions<MusicStreamingSettings> musicStreamingSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbContextFactory<AzzyDbContext> dbContextFactory) : IHostedService
+public sealed class CoreServiceHost(ILogger<CoreServiceHost> logger, IOptions<AzzyBotSettings> azzySettings, IOptions<DatabaseSettings> dbSettings, IOptions<DiscordStatusSettings> discordSettings, IOptions<MusicStreamingSettings> musicStreamingSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbContextFactory<AzzyDbContext> dbContextFactory) : ICoreServiceHost
 {
     private readonly ILogger<CoreServiceHost> _logger = logger;
     private readonly AzzyBotSettings _azzySettings = azzySettings.Value;

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastApiService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization.Metadata;
+using System.Threading.Tasks;
+
+using AzzyBot.Bot.Utilities.Records.AzuraCast;
+using AzzyBot.Data.Entities;
+
+using DSharpPlus.Commands.Processors.SlashCommands;
+
+namespace AzzyBot.Bot.Services.Modules.Interfaces;
+
+public interface IAzuraCastApiService
+{
+    string AzuraCastPermissionsWiki { get; }
+    string FilePath { get; }
+    Task CheckForApiPermissionsAsync(AzuraCastEntity azuraCast);
+    Task CheckForApiPermissionsAsync(AzuraCastStationEntity station);
+    Task DeleteStationSongRequestAsync(Uri baseUrl, string apiKey, int stationId, int requestId = 0);
+    Task DownloadPlaylistAsync(Uri url, string apiKey, string downloadPath);
+    Task<string> DownloadSongArtworkAsync(Uri url, string apiKey, string downloadPath);
+    Task<IEnumerable<AzuraFilesRecord>> GetFilesLocalAsync(int guildId, int azuraCastId, int databaseId, int stationId);
+    Task<IEnumerable<AzuraFilesRecord>?> GetFilesOnlineBasicAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<IEnumerable<AzuraFilesDetailedRecord>?> GetFilesOnlineDetailedAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<AzuraHardwareStatsRecord?> GetHardwareStatsAsync(Uri baseUrl, string apiKey);
+    Task<AzuraStatusRecord?> GetInstanceStatusAsync(Uri baseUrl);
+    Task<AzuraNowPlayingDataRecord?> GetNowPlayingAsync(Uri baseUrl, string apiKey, int stationId, bool noLogging = false);
+    Task<AzuraPlaylistRecord?> GetPlaylistAsync(Uri baseUrl, string apiKey, int stationId, int playlistId);
+    Task<IEnumerable<AzuraPlaylistRecord>?> GetPlaylistsAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<IEnumerable<AzuraPlaylistRecord>?> GetPlaylistsWithRequestsAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<AzuraRequestRecord?> GetRequestableSongAsync(Uri baseUrl, string apiKey, int stationId, string? songId = null, string? name = null, string? artist = null, string? album = null);
+    Task<IEnumerable<AzuraRequestRecord>?> GetRequestableSongsAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<IEnumerable<AzuraMediaItemRecord>?> GetSongsInPlaylistAsync(Uri baseUrl, string apiKey, int stationId, AzuraPlaylistRecord playlist);
+    Task<AzuraSongDataRecord?> GetSongInfoAsync(Uri baseUrl, string apiKey, AzuraCastStationEntity station, bool online, string? uniqueId = null, string? songId = null, string? name = null, string? artist = null, string? album = null);
+    Task<AzuraStationRecord?> GetStationAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<AzuraAdminStationConfigRecord?> GetStationAdminConfigAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<IEnumerable<AzuraStationHistoryItemRecord>?> GetStationHistoryAsync(Uri baseUrl, string apiKey, int stationId, in DateTimeOffset startHistory, in DateTimeOffset endHistory);
+    Task<IEnumerable<AzuraHlsMountRecord>?> GetStationHlsMountPointsAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<IEnumerable<AzuraStationListenerRecord>?> GetStationListenersAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<IEnumerable<AzuraStationQueueItemDetailedRecord>?> GetStationQueueAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<IEnumerable<AzuraRequestQueueItemRecord>?> GetStationRequestItemsAsync(Uri baseUrl, string apiKey, int stationId, bool history);
+    Task<AzuraSystemLogRecord?> GetSystemLogAsync(Uri baseUrl, string apiKey, string logName);
+    Task<AzuraSystemLogsRecord?> GetSystemLogsAsync(Uri baseUrl, string apiKey);
+    Task<string?> GetUpdatesAsync(Uri baseUrl, string apiKey);
+    Task ModifyStationAdminConfigAsync(Uri baseUrl, string apiKey, int stationId, AzuraAdminStationConfigRecord config);
+    Task RequestInternalSongAsync(Uri baseUrl, string apiKey, int stationId, string songPath);
+    Task RequestSongAsync(Uri baseUrl, int stationId, string requestId);
+    Task SkipSongAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<bool> StartStationAsync(Uri baseUrl, string apiKey, int stationId, SlashCommandContext context);
+    Task<bool> StopStationAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<List<AzuraPlaylistStateRecord>?> SwitchPlaylistsAsync(Uri baseUrl, string apiKey, int stationId, int playlistId, bool removeOld);
+    Task TogglePlaylistAsync(Uri baseUrl, string apiKey, int stationId, int playlistId);
+    Task UpdateInstanceAsync(Uri baseUrl, string apiKey);
+    Task<T?> UploadFileAsync<T>(Uri baseUrl, string apiKey, int stationId, string file, string fileName, string filePath, JsonTypeInfo<T> jsonType);
+}

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastFileService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastFileService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+using AzzyBot.Data.Entities;
+
+namespace AzzyBot.Bot.Services.Modules.Interfaces;
+
+public interface IAzuraCastFileService
+{
+    Task CheckForFileChangesAsync(AzuraCastStationEntity station);
+}

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastPingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastPingService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+using AzzyBot.Data.Entities;
+
+namespace AzzyBot.Bot.Services.Modules.Interfaces;
+
+public interface IAzuraCastPingService
+{
+    Task PingInstanceAsync(AzuraCastEntity azuraCast);
+}

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastUpdateService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastUpdateService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+using AzzyBot.Data.Entities;
+
+namespace AzzyBot.Bot.Services.Modules.Interfaces;
+
+public interface IAzuraCastUpdateService
+{
+    Task CheckForAzuraCastUpdatesAsync(AzuraCastEntity azuraCast, bool forced = false);
+}

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/ICoreService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/ICoreService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using AzzyBot.Bot.Utilities.Structs;
+using AzzyBot.Data.Entities;
+
+namespace AzzyBot.Bot.Services.Modules.Interfaces;
+
+public interface ICoreService
+{
+    Task<IReadOnlyDictionary<GuildEntity, AzzyInactiveGuildStruct>> CheckUnusedGuildsAsync();
+    Task<int> DeleteUnusedGuildsAsync(IReadOnlyDictionary<GuildEntity, AzzyInactiveGuildStruct> guilds);
+    Task<int> NotifyUnusedGuildsAsync(IReadOnlyDictionary<GuildEntity, AzzyInactiveGuildStruct> guilds);
+}

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/ICoreServiceHost.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/ICoreServiceHost.cs
@@ -1,0 +1,5 @@
+using Microsoft.Extensions.Hosting;
+
+namespace AzzyBot.Bot.Services.Modules.Interfaces;
+
+public interface ICoreServiceHost : IHostedService;

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/IMusicStreamingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/IMusicStreamingService.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using DSharpPlus.Commands.Processors.SlashCommands;
+
+using Lavalink4NET.Players;
+using Lavalink4NET.Rest.Entities.Tracks;
+using Lavalink4NET.Tracks;
+
+namespace AzzyBot.Bot.Services.Modules.Interfaces;
+
+public interface IMusicStreamingService
+{
+    LavalinkPlayer? GetLavalinkPlayer(ulong guildId);
+    Task<bool> CheckIfPlayedMusicIsStationAsync(SlashCommandContext context, string station);
+    Task<bool> ClearQueueAsync(SlashCommandContext context, int position = -1);
+    TimeSpan? GetCurrentPosition(ulong guildId);
+    Task<TimeSpan?> GetCurrentPositionAsync(SlashCommandContext context);
+    Task<IEnumerable<ITrackQueueItem>?> HistoryAsync(SlashCommandContext context, bool queue = false);
+    Task<bool> JoinChannelAsync(SlashCommandContext context);
+    LavalinkTrack? NowPlaying(ulong guildId);
+    Task<LavalinkTrack?> NowPlayingAsync(SlashCommandContext context);
+    Task<bool> PauseAsync(SlashCommandContext context);
+    Task<string?> PlayMusicAsync(SlashCommandContext context, string query, TrackSearchMode searchMode, float volume);
+    Task<bool> PlayMountMusicAsync(SlashCommandContext context, string mountPoint, float volume);
+    Task<bool> ResumeAsync(SlashCommandContext context);
+    Task<bool> SetVolumeAsync(SlashCommandContext context, float volume);
+    Task<bool> SkipSongAsync(SlashCommandContext context, int count = 1);
+    Task<bool> StopMusicAsync(SlashCommandContext context, bool disconnect = false);
+}

--- a/src/AzzyBot.Bot/Services/Modules/MusicStreamingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/MusicStreamingService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Bot/Services/Modules/MusicStreamingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/MusicStreamingService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
@@ -24,11 +25,11 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class MusicStreamingService(IAudioService audioService, ILogger<MusicStreamingService> logger, DiscordBotService botService)
+public sealed class MusicStreamingService(IAudioService audioService, ILogger<MusicStreamingService> logger, IDiscordBotService botService)
 {
     private readonly IAudioService _audioService = audioService;
     private readonly ILogger<MusicStreamingService> _logger = logger;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
 
     public LavalinkPlayer? GetLavalinkPlayer(ulong guildId)
     {

--- a/src/AzzyBot.Bot/Services/Modules/MusicStreamingService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/MusicStreamingService.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Bot.Services.Modules.Interfaces;
 using AzzyBot.Bot.Utilities.Helpers;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
@@ -25,7 +26,7 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services.Modules;
 
-public sealed class MusicStreamingService(IAudioService audioService, ILogger<MusicStreamingService> logger, IDiscordBotService botService)
+public sealed class MusicStreamingService(IAudioService audioService, ILogger<MusicStreamingService> logger, IDiscordBotService botService) : IMusicStreamingService
 {
     private readonly IAudioService _audioService = audioService;
     private readonly ILogger<MusicStreamingService> _logger = logger;

--- a/src/AzzyBot.Bot/Services/UpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/UpdaterService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text.Json;

--- a/src/AzzyBot.Bot/Services/UpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/UpdaterService.cs
@@ -61,7 +61,7 @@ public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<Azzy
             return;
         }
 
-        await _dbActions.UpdateAzzyBotAsync(lastUpdateCheck: true);
+        await _dbActions.UpdateAzzyBotAsync(updateLastUpdateCheck: true);
 
         string onlineVersion = updaterRecord.Name;
         if (localVersion == onlineVersion)

--- a/src/AzzyBot.Bot/Services/UpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/UpdaterService.cs
@@ -19,13 +19,13 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<AzzyBotSettings> botSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbActions dbActions, DiscordBotService botService, IWebRequestService webService) : IUpdaterService
+public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<AzzyBotSettings> botSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webService) : IUpdaterService
 {
     private readonly ILogger<UpdaterService> _logger = logger;
     private readonly AzzyBotSettings _botSettings = botSettings.Value;
     private readonly CoreUpdaterSettings _updaterSettings = updaterSettings.Value;
     private readonly IDbActions _dbActions = dbActions;
-    private readonly DiscordBotService _botService = botService;
+    private readonly IDiscordBotService _botService = botService;
     private readonly IWebRequestService _webService = webService;
     private DateTimeOffset _lastAzzyUpdateNotificationTime = DateTimeOffset.MinValue;
     private string _lastOnlineVersion = string.Empty;

--- a/src/AzzyBot.Bot/Services/UpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/UpdaterService.cs
@@ -9,7 +9,7 @@ using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records;
 using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities;
-using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Entities;
 
@@ -18,12 +18,12 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<AzzyBotSettings> botSettings, IOptions<CoreUpdaterSettings> updaterSettings, DbActions dbActions, DiscordBotService botService, WebRequestService webService)
+public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<AzzyBotSettings> botSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbActions dbActions, DiscordBotService botService, WebRequestService webService)
 {
     private readonly ILogger<UpdaterService> _logger = logger;
     private readonly AzzyBotSettings _botSettings = botSettings.Value;
     private readonly CoreUpdaterSettings _updaterSettings = updaterSettings.Value;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
     private readonly WebRequestService _webService = webService;
     private DateTimeOffset _lastAzzyUpdateNotificationTime = DateTimeOffset.MinValue;

--- a/src/AzzyBot.Bot/Services/UpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/UpdaterService.cs
@@ -19,14 +19,14 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<AzzyBotSettings> botSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbActions dbActions, DiscordBotService botService, WebRequestService webService) : IUpdaterService
+public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<AzzyBotSettings> botSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbActions dbActions, DiscordBotService botService, IWebRequestService webService) : IUpdaterService
 {
     private readonly ILogger<UpdaterService> _logger = logger;
     private readonly AzzyBotSettings _botSettings = botSettings.Value;
     private readonly CoreUpdaterSettings _updaterSettings = updaterSettings.Value;
     private readonly IDbActions _dbActions = dbActions;
     private readonly DiscordBotService _botService = botService;
-    private readonly WebRequestService _webService = webService;
+    private readonly IWebRequestService _webService = webService;
     private DateTimeOffset _lastAzzyUpdateNotificationTime = DateTimeOffset.MinValue;
     private string _lastOnlineVersion = string.Empty;
     private int _azzyNotifyCounter;

--- a/src/AzzyBot.Bot/Services/UpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/UpdaterService.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Text.Json;
 using System.Threading.Tasks;
 
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Settings;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records;
@@ -18,7 +19,7 @@ using Microsoft.Extensions.Options;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<AzzyBotSettings> botSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbActions dbActions, DiscordBotService botService, WebRequestService webService)
+public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<AzzyBotSettings> botSettings, IOptions<CoreUpdaterSettings> updaterSettings, IDbActions dbActions, DiscordBotService botService, WebRequestService webService) : IUpdaterService
 {
     private readonly ILogger<UpdaterService> _logger = logger;
     private readonly AzzyBotSettings _botSettings = botSettings.Value;
@@ -72,25 +73,6 @@ public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<Azzy
         await SendUpdateMessageAsync(onlineVersion, releaseDate, updaterRecord.Body);
     }
 
-    public static bool CheckUpdateNotification(int notifyCounter, in DateTimeOffset lastNotificationTime)
-    {
-        DateTimeOffset now = DateTimeOffset.UtcNow;
-        if (notifyCounter < 3 && now - lastNotificationTime > TimeSpan.FromHours(23.98))
-        {
-            return true;
-        }
-        else if (notifyCounter >= 3 && now - lastNotificationTime > TimeSpan.FromHours(11.98))
-        {
-            return true;
-        }
-        else if (notifyCounter >= 7 && now - lastNotificationTime > TimeSpan.FromHours(5.98))
-        {
-            return true;
-        }
-
-        return false;
-    }
-
     private async Task SendUpdateMessageAsync(string updateVersion, DateTimeOffset releaseDate, string changelog)
     {
         if (_lastOnlineVersion != updateVersion)
@@ -99,7 +81,7 @@ public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<Azzy
             _azzyNotifyCounter = 0;
         }
 
-        if (!CheckUpdateNotification(_azzyNotifyCounter, _lastAzzyUpdateNotificationTime))
+        if (!Misc.CheckUpdateNotification(_azzyNotifyCounter, _lastAzzyUpdateNotificationTime))
             return;
 
         _lastAzzyUpdateNotificationTime = DateTimeOffset.UtcNow;

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -197,7 +197,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
                 responseContent = await response.Content.ReadAsStringAsync();
             }
 
-            const int maxRetries= 7;
+            const int maxRetries = 7;
             int retryCount = 0;
             while (status is HttpStatusCode.TooManyRequests && retryCount <= maxRetries)
             {

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Resources;
+using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records;
 using AzzyBot.Core.Logging;
@@ -19,10 +20,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebRequestService> logger)
+public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebRequestService> logger) : IWebRequestService
 {
     private readonly IHttpClientFactory _factory = factory;
-    private readonly ILogger _logger = logger;
+    private readonly ILogger<WebRequestService> _logger = logger;
     private const string MediaTypeJson = MediaTypeNames.Application.Json;
     private static readonly string HttpClientName = SoftwareStats.GetAppName;
 

--- a/src/AzzyBot.Bot/Settings/AppSettingsRecord.cs
+++ b/src/AzzyBot.Bot/Settings/AppSettingsRecord.cs
@@ -1,4 +1,4 @@
-﻿using AzzyBot.Data.Settings;
+using AzzyBot.Data.Settings;
 
 namespace AzzyBot.Bot.Settings;
 

--- a/src/AzzyBot.Bot/Settings/AzzyBotSettings.cs
+++ b/src/AzzyBot.Bot/Settings/AzzyBotSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 

--- a/src/AzzyBot.Bot/Settings/Validators/AppStatsValidator.cs
+++ b/src/AzzyBot.Bot/Settings/Validators/AppStatsValidator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 using AzzyBot.Core.Utilities.Records;
 

--- a/src/AzzyBot.Bot/Settings/Validators/AzzyBotSettingsValidator.cs
+++ b/src/AzzyBot.Bot/Settings/Validators/AzzyBotSettingsValidator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Extensions.Options;
 

--- a/src/AzzyBot.Bot/Settings/Validators/CoreUpdaterValidator.cs
+++ b/src/AzzyBot.Bot/Settings/Validators/CoreUpdaterValidator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Extensions.Options;
 

--- a/src/AzzyBot.Bot/Settings/Validators/DatabaseSettingsValidator.cs
+++ b/src/AzzyBot.Bot/Settings/Validators/DatabaseSettingsValidator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 using AzzyBot.Data.Settings;
 

--- a/src/AzzyBot.Bot/Settings/Validators/DiscordStatusSettingsValidator.cs
+++ b/src/AzzyBot.Bot/Settings/Validators/DiscordStatusSettingsValidator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Extensions.Options;
 

--- a/src/AzzyBot.Bot/Settings/Validators/MusicStreamingSettingsValidator.cs
+++ b/src/AzzyBot.Bot/Settings/Validators/MusicStreamingSettingsValidator.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.Extensions.Options;
 

--- a/src/AzzyBot.Bot/Utilities/AzuraFileChecker.cs
+++ b/src/AzzyBot.Bot/Utilities/AzuraFileChecker.cs
@@ -1,4 +1,4 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 using AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/AzuraFileComparer.cs
+++ b/src/AzzyBot.Bot/Utilities/AzuraFileComparer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/AzzyBot.Bot/Utilities/AzzyHelp.cs
+++ b/src/AzzyBot.Bot/Utilities/AzzyHelp.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/src/AzzyBot.Bot/Utilities/Enums/AzuraCastDiscordPerm.cs
+++ b/src/AzzyBot.Bot/Utilities/Enums/AzuraCastDiscordPerm.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Bot.Utilities.Enums;
+namespace AzzyBot.Bot.Utilities.Enums;
 
 public enum AzuraCastDiscordPerm
 {

--- a/src/AzzyBot.Bot/Utilities/Enums/AzzyModules.cs
+++ b/src/AzzyBot.Bot/Utilities/Enums/AzzyModules.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Bot.Utilities.Enums;
+namespace AzzyBot.Bot.Utilities.Enums;
 
 public enum AzzyModules
 {

--- a/src/AzzyBot.Bot/Utilities/Helpers/AzuraApiFilters.cs
+++ b/src/AzzyBot.Bot/Utilities/Helpers/AzuraApiFilters.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Bot.Utilities.Helpers;
+namespace AzzyBot.Bot.Utilities.Helpers;
 
 public static class AzuraApiFilters
 {

--- a/src/AzzyBot.Bot/Utilities/Helpers/GeneralStrings.cs
+++ b/src/AzzyBot.Bot/Utilities/Helpers/GeneralStrings.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Bot.Utilities.Helpers;
+namespace AzzyBot.Bot.Utilities.Helpers;
 
 public static class GeneralStrings
 {

--- a/src/AzzyBot.Bot/Utilities/Helpers/ModuleCheckMessages.cs
+++ b/src/AzzyBot.Bot/Utilities/Helpers/ModuleCheckMessages.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Bot.Utilities.Helpers;
+namespace AzzyBot.Bot.Utilities.Helpers;
 
 public static class ModuleCheckMessages
 {

--- a/src/AzzyBot.Bot/Utilities/JsonSourceGen.cs
+++ b/src/AzzyBot.Bot/Utilities/JsonSourceGen.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraAdminStationConfigRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraAdminStationConfigRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraCustomQueueItemRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraCustomQueueItemRecord.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraErrorRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraErrorRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraFilesRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraFilesRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraMountRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraMountRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraRequestRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraRequestRecord.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationHistoryItemRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationHistoryItemRecord.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationListenerRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationListenerRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationQueueItemRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationQueueItemRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationStatusRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStationStatusRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStatusRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraStatusRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraUpdateErrorRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraUpdateErrorRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraUpdateRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraUpdateRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzzyDiscordEmbedRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzzyDiscordEmbedRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Bot.Utilities.Records;
+namespace AzzyBot.Bot.Utilities.Records;
 
 /// <summary>
 /// Represents an embed field for a Discord message.

--- a/src/AzzyBot.Bot/Utilities/Records/AzzyHelpRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzzyHelpRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace AzzyBot.Bot.Utilities.Records;
 

--- a/src/AzzyBot.Bot/Utilities/Records/AzzyIpAddressRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzzyIpAddressRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Bot.Utilities.Records;
+namespace AzzyBot.Bot.Utilities.Records;
 
 /// <summary>
 /// Represents an IP address record.

--- a/src/AzzyBot.Bot/Utilities/Records/AzzyUpdateRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzzyUpdateRecord.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace AzzyBot.Bot.Utilities.Records;
 

--- a/src/AzzyBot.Bot/Utilities/Structs/AzzyInactiveGuildStruct.cs
+++ b/src/AzzyBot.Bot/Utilities/Structs/AzzyInactiveGuildStruct.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using DSharpPlus.Entities;
 

--- a/src/AzzyBot.Bot/Utilities/Structs/EmbedAuthorStruct.cs
+++ b/src/AzzyBot.Bot/Utilities/Structs/EmbedAuthorStruct.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace AzzyBot.Bot.Utilities.Structs;

--- a/src/AzzyBot.Core/Logging/LoggerActions.cs
+++ b/src/AzzyBot.Core/Logging/LoggerActions.cs
@@ -192,6 +192,9 @@ public static partial class LoggerActions
     [LoggerMessage(224, LogLevel.Warning, "Bot status user status {status} is not defined, falling back to Online")]
     public static partial void BotStatusUserStatusNotDefined(this ILogger logger, int status);
 
+    [LoggerMessage(225, LogLevel.Warning, "Bot status activity type Streaming requires a Twitch or YouTube URL, falling back to Playing")]
+    public static partial void BotStatusStreamingInvalidUrl(this ILogger logger);
+
     [LoggerMessage(230, LogLevel.Warning, "Bot is ratelimited on uri: {uri} retrying in {time} seconds")]
     public static partial void BotRatelimited(this ILogger logger, Uri uri, int time);
 

--- a/src/AzzyBot.Core/Logging/LoggerActions.cs
+++ b/src/AzzyBot.Core/Logging/LoggerActions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Net.Http;
 
 using Microsoft.Extensions.Logging;

--- a/src/AzzyBot.Core/Logging/LoggerActions.cs
+++ b/src/AzzyBot.Core/Logging/LoggerActions.cs
@@ -114,6 +114,15 @@ public static partial class LoggerActions
     [LoggerMessage(113, LogLevel.Information, "Sent the bot-wide info message to {count} guilds")]
     public static partial void BotWideMessageSent(this ILogger logger, int count);
 
+    [LoggerMessage(114, LogLevel.Information, "Bot status activity type set to {activityType} with doing '{doing}'")]
+    public static partial void BotStatusActivitySet(this ILogger logger, string activityType, string doing);
+
+    [LoggerMessage(115, LogLevel.Information, "Bot status stream URL set to {url}")]
+    public static partial void BotStatusStreamUrlSet(this ILogger logger, string url);
+
+    [LoggerMessage(116, LogLevel.Information, "Bot status user status set to {userStatus}")]
+    public static partial void BotStatusUserStatusSet(this ILogger logger, string userStatus);
+
     [LoggerMessage(120, LogLevel.Information, "Database concurrency situation resolved.")]
     public static partial void DatabaseConcurrencyResolved(this ILogger logger);
 
@@ -173,6 +182,15 @@ public static partial class LoggerActions
 
     [LoggerMessage(221, LogLevel.Warning, "Could not find referenced command {command}")]
     public static partial void CommandNotFound(this ILogger logger, string command);
+
+    [LoggerMessage(222, LogLevel.Warning, "Bot status activity type {type} is not defined, falling back to ListeningTo")]
+    public static partial void BotStatusActivityTypeNotDefined(this ILogger logger, int type);
+
+    [LoggerMessage(223, LogLevel.Warning, "Bot status activity type Streaming requires a URL, falling back to Playing")]
+    public static partial void BotStatusStreamingRequiresUrl(this ILogger logger);
+
+    [LoggerMessage(224, LogLevel.Warning, "Bot status user status {status} is not defined, falling back to Online")]
+    public static partial void BotStatusUserStatusNotDefined(this ILogger logger, int status);
 
     [LoggerMessage(230, LogLevel.Warning, "Bot is ratelimited on uri: {uri} retrying in {time} seconds")]
     public static partial void BotRatelimited(this ILogger logger, Uri uri, int time);

--- a/src/AzzyBot.Core/Utilities/Encryption/Crypto.cs
+++ b/src/AzzyBot.Core/Utilities/Encryption/Crypto.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Security.Cryptography;
 using System.Text;
 

--- a/src/AzzyBot.Core/Utilities/FileOperations.cs
+++ b/src/AzzyBot.Core/Utilities/FileOperations.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/AzzyBot.Core/Utilities/HardwareStats.cs
+++ b/src/AzzyBot.Core/Utilities/HardwareStats.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;

--- a/src/AzzyBot.Core/Utilities/Helpers/FileSizes.cs
+++ b/src/AzzyBot.Core/Utilities/Helpers/FileSizes.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Core.Utilities.Helpers;
+namespace AzzyBot.Core.Utilities.Helpers;
 
 public static class FileSizes
 {

--- a/src/AzzyBot.Core/Utilities/Misc.cs
+++ b/src/AzzyBot.Core/Utilities/Misc.cs
@@ -10,21 +10,15 @@ public static class Misc
 {
     public static bool CheckUpdateNotification(int notifyCounter, in DateTimeOffset lastNotificationTime)
     {
-        DateTimeOffset now = DateTimeOffset.UtcNow;
-        if (notifyCounter < 3 && now - lastNotificationTime > TimeSpan.FromHours(23.98))
-        {
-            return true;
-        }
-        else if (notifyCounter >= 3 && now - lastNotificationTime > TimeSpan.FromHours(11.98))
-        {
-            return true;
-        }
-        else if (notifyCounter >= 7 && now - lastNotificationTime > TimeSpan.FromHours(5.98))
-        {
-            return true;
-        }
+        TimeSpan elapsed = DateTimeOffset.UtcNow - lastNotificationTime;
 
-        return false;
+        return notifyCounter switch
+        {
+            >= 7 when elapsed > TimeSpan.FromHours(5.98) => true,
+            >= 3 when elapsed > TimeSpan.FromHours(11.98) => true,
+            < 3 when elapsed > TimeSpan.FromHours(23.98) => true,
+            _ => false
+        };
     }
 
     public static string GetProgressBar(double number, double elapsed, double duration)

--- a/src/AzzyBot.Core/Utilities/Misc.cs
+++ b/src/AzzyBot.Core/Utilities/Misc.cs
@@ -8,6 +8,25 @@ namespace AzzyBot.Core.Utilities;
 
 public static class Misc
 {
+    public static bool CheckUpdateNotification(int notifyCounter, in DateTimeOffset lastNotificationTime)
+    {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        if (notifyCounter < 3 && now - lastNotificationTime > TimeSpan.FromHours(23.98))
+        {
+            return true;
+        }
+        else if (notifyCounter >= 3 && now - lastNotificationTime > TimeSpan.FromHours(11.98))
+        {
+            return true;
+        }
+        else if (notifyCounter >= 7 && now - lastNotificationTime > TimeSpan.FromHours(5.98))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     public static string GetProgressBar(double number, double elapsed, double duration)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(number);

--- a/src/AzzyBot.Core/Utilities/Records/AppCpuLoadRecord.cs
+++ b/src/AzzyBot.Core/Utilities/Records/AppCpuLoadRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Core.Utilities.Records;
+namespace AzzyBot.Core.Utilities.Records;
 
 /// <summary>
 /// Represents the CPU load of the hardware.

--- a/src/AzzyBot.Core/Utilities/Records/AppDiskUsageRecord.cs
+++ b/src/AzzyBot.Core/Utilities/Records/AppDiskUsageRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Core.Utilities.Records;
+namespace AzzyBot.Core.Utilities.Records;
 
 /// <summary>
 /// Represents the disk usage of the hardware.

--- a/src/AzzyBot.Core/Utilities/Records/AppMemoryUsageRecord.cs
+++ b/src/AzzyBot.Core/Utilities/Records/AppMemoryUsageRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Core.Utilities.Records;
+namespace AzzyBot.Core.Utilities.Records;
 
 /// <summary>
 /// Represents the memory usage of the hardware.

--- a/src/AzzyBot.Core/Utilities/Records/AppNetworkSpeedRecord.cs
+++ b/src/AzzyBot.Core/Utilities/Records/AppNetworkSpeedRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Core.Utilities.Records;
+namespace AzzyBot.Core.Utilities.Records;
 
 /// <summary>
 /// Represents the network speed of the hardware.

--- a/src/AzzyBot.Core/Utilities/Records/AppNetworkStatsRecord.cs
+++ b/src/AzzyBot.Core/Utilities/Records/AppNetworkStatsRecord.cs
@@ -1,4 +1,4 @@
-﻿namespace AzzyBot.Core.Utilities.Records;
+namespace AzzyBot.Core.Utilities.Records;
 
 /// <summary>
 /// Represents the network statistics for the hardware.

--- a/src/AzzyBot.Core/Utilities/Records/AppStats.cs
+++ b/src/AzzyBot.Core/Utilities/Records/AppStats.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 

--- a/src/AzzyBot.Data/Entities/AzuraCastChecksEntity.cs
+++ b/src/AzzyBot.Data/Entities/AzuraCastChecksEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace AzzyBot.Data.Entities;

--- a/src/AzzyBot.Data/Entities/AzuraCastEntity.cs
+++ b/src/AzzyBot.Data/Entities/AzuraCastEntity.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;

--- a/src/AzzyBot.Data/Entities/AzuraCastPreferencesEntity.cs
+++ b/src/AzzyBot.Data/Entities/AzuraCastPreferencesEntity.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 using DSharpPlus.Entities;
 

--- a/src/AzzyBot.Data/Entities/AzuraCastStationChecksEntity.cs
+++ b/src/AzzyBot.Data/Entities/AzuraCastStationChecksEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace AzzyBot.Data.Entities;

--- a/src/AzzyBot.Data/Entities/AzuraCastStationEntity.cs
+++ b/src/AzzyBot.Data/Entities/AzuraCastStationEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 

--- a/src/AzzyBot.Data/Entities/AzuraCastStationPreferencesEntity.cs
+++ b/src/AzzyBot.Data/Entities/AzuraCastStationPreferencesEntity.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 using DSharpPlus.Entities;
 

--- a/src/AzzyBot.Data/Entities/AzuraCastStationRequestEntity.cs
+++ b/src/AzzyBot.Data/Entities/AzuraCastStationRequestEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace AzzyBot.Data.Entities;

--- a/src/AzzyBot.Data/Entities/AzzyBotEntity.cs
+++ b/src/AzzyBot.Data/Entities/AzzyBotEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace AzzyBot.Data.Entities;

--- a/src/AzzyBot.Data/Entities/GuildEntity.cs
+++ b/src/AzzyBot.Data/Entities/GuildEntity.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 using DSharpPlus.Entities;

--- a/src/AzzyBot.Data/Entities/GuildPreferencesEntity.cs
+++ b/src/AzzyBot.Data/Entities/GuildPreferencesEntity.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 using DSharpPlus.Entities;
 

--- a/src/AzzyBot.Data/Entities/MusicStreamingEntity.cs
+++ b/src/AzzyBot.Data/Entities/MusicStreamingEntity.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 using DSharpPlus.Entities;
 

--- a/src/AzzyBot.Data/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Data/Extensions/IServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;

--- a/src/AzzyBot.Data/Extensions/IServiceCollectionExtensions.cs
+++ b/src/AzzyBot.Data/Extensions/IServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System.Text;
 
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Services;
+using AzzyBot.Data.Services.Interfaces;
 using AzzyBot.Data.Settings;
 
 using EntityFramework.Exceptions.PostgreSQL;
@@ -66,8 +67,8 @@ public static class IServiceCollectionExtensions
 #else
             services.AddPooledDbContextFactory<AzzyDbContext>(o => o.UseNpgsql(connectionString, o => o.EnableRetryOnFailure().SetPostgresVersion(settings.DatabaseVersion)).UseExceptionProcessor());
 #endif
-            services.AddSingleton<DbActions>();
-            services.AddSingleton<DbMaintenance>();
+            services.AddSingleton<IDbActions, DbActions>();
+            services.AddSingleton<IDbMaintenance, DbMaintenance>();
         }
     }
 }

--- a/src/AzzyBot.Data/Services/AzzyDbContext.cs
+++ b/src/AzzyBot.Data/Services/AzzyDbContext.cs
@@ -1,4 +1,4 @@
-﻿using AzzyBot.Data.Entities;
+using AzzyBot.Data.Entities;
 
 using Microsoft.EntityFrameworkCore;
 

--- a/src/AzzyBot.Data/Services/DbActions.cs
+++ b/src/AzzyBot.Data/Services/DbActions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/AzzyBot.Data/Services/DbActions.cs
+++ b/src/AzzyBot.Data/Services/DbActions.cs
@@ -653,7 +653,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         }
     }
 
-    public async Task UpdateAzuraCastStationChecksAsync(ulong guildId, int stationId, bool? fileChanges = null, bool? lastFileChangesCheck = null)
+    public async Task UpdateAzuraCastStationChecksAsync(ulong guildId, int stationId, bool? fileChanges = null, bool updateLastFileChangesCheck = false)
     {
         await using AzzyDbContext dbContext = _dbContextFactory.CreateDbContext();
 
@@ -670,7 +670,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         if (fileChanges.HasValue)
             checks.FileChanges = fileChanges.Value;
 
-        if (lastFileChangesCheck.HasValue)
+        if (updateLastFileChangesCheck)
             checks.LastFileChangesCheck = DateTimeOffset.UtcNow;
 
         dbContext.AzuraCastStationChecks.Update(checks);
@@ -684,7 +684,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
             _logger.DatabaseConcurrencyException(ex);
 
             await HandleConcurrencyExceptionAsync(ex.Entries);
-            await UpdateAzuraCastStationChecksAsync(guildId, stationId, fileChanges, lastFileChangesCheck);
+            await UpdateAzuraCastStationChecksAsync(guildId, stationId, fileChanges, updateLastFileChangesCheck);
 
             _logger.DatabaseConcurrencyResolved();
         }
@@ -745,7 +745,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         }
     }
 
-    public async Task UpdateAzzyBotAsync(bool? lastDatabaseCleanup = null, bool? lastGuildReminder = null, bool? lastUpdateCheck = null)
+    public async Task UpdateAzzyBotAsync(bool updateLastDatabaseCleanup = false, bool updateLastGuildReminder = false, bool updateLastUpdateCheck = false)
     {
         await using AzzyDbContext dbContext = _dbContextFactory.CreateDbContext();
 
@@ -757,13 +757,13 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         }
 
         DateTimeOffset now = DateTimeOffset.UtcNow;
-        if (lastDatabaseCleanup.HasValue)
+        if (updateLastDatabaseCleanup)
             azzyBot.LastDatabaseCleanup = now;
 
-        if (lastGuildReminder.HasValue)
+        if (updateLastGuildReminder)
             azzyBot.LastGuildReminderCheck = now;
 
-        if (lastUpdateCheck.HasValue)
+        if (updateLastUpdateCheck)
             azzyBot.LastUpdateCheck = now;
 
         dbContext.AzzyBot.Update(azzyBot);
@@ -777,13 +777,13 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
             _logger.DatabaseConcurrencyException(ex);
 
             await HandleConcurrencyExceptionAsync(ex.Entries);
-            await UpdateAzzyBotAsync(lastDatabaseCleanup, lastGuildReminder, lastUpdateCheck);
+            await UpdateAzzyBotAsync(updateLastDatabaseCleanup, updateLastGuildReminder, updateLastUpdateCheck);
 
             _logger.DatabaseConcurrencyResolved();
         }
     }
 
-    public async Task UpdateGuildAsync(ulong guildId, bool? lastPermissionCheck = null, DateTimeOffset? reminderLeaveDate = null, bool? legalsAccepted = null)
+    public async Task UpdateGuildAsync(ulong guildId, bool updateLastPermissionCheck = false, DateTimeOffset? reminderLeaveDate = null, bool? legalsAccepted = null)
     {
         await using AzzyDbContext dbContext = _dbContextFactory.CreateDbContext();
 
@@ -798,7 +798,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         }
 
         DateTimeOffset now = DateTimeOffset.UtcNow;
-        if (lastPermissionCheck.HasValue)
+        if (updateLastPermissionCheck)
             guild.LastPermissionCheck = now;
 
         if (reminderLeaveDate.HasValue)
@@ -825,7 +825,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
             _logger.DatabaseConcurrencyException(ex);
 
             await HandleConcurrencyExceptionAsync(ex.Entries);
-            await UpdateGuildAsync(guildId, lastPermissionCheck, reminderLeaveDate, legalsAccepted);
+            await UpdateGuildAsync(guildId, updateLastPermissionCheck, reminderLeaveDate, legalsAccepted);
 
             _logger.DatabaseConcurrencyResolved();
         }

--- a/src/AzzyBot.Data/Services/DbActions.cs
+++ b/src/AzzyBot.Data/Services/DbActions.cs
@@ -610,22 +610,22 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         }
     }
 
-    public async Task UpdateAzuraCastStationAsync(ulong guildId, int station, int? stationId = null, string? apiKey = null, bool updateLastSkipTime = false, bool updateLastRequestTime = false)
+    public async Task UpdateAzuraCastStationAsync(ulong guildId, int currStationId, int? newStationId = null, string? apiKey = null, bool updateLastSkipTime = false, bool updateLastRequestTime = false)
     {
         await using AzzyDbContext dbContext = _dbContextFactory.CreateDbContext();
 
         AzuraCastStationEntity? azuraStation = await dbContext.AzuraCastStations
-            .Where(s => s.AzuraCast.Guild.UniqueId == guildId && s.StationId == station)
+            .Where(s => s.AzuraCast.Guild.UniqueId == guildId && s.StationId == currStationId)
             .SingleOrDefaultAsync();
 
         if (azuraStation is null)
         {
-            _logger.DatabaseAzuraCastStationNotFound(guildId, 0, station);
+            _logger.DatabaseAzuraCastStationNotFound(guildId, 0, currStationId);
             return;
         }
 
-        if (stationId.HasValue)
-            azuraStation.StationId = stationId.Value;
+        if (newStationId.HasValue)
+            azuraStation.StationId = newStationId.Value;
 
         if (!string.IsNullOrEmpty(apiKey))
             azuraStation.ApiKey = Crypto.Encrypt(apiKey);
@@ -647,7 +647,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
             _logger.DatabaseConcurrencyException(ex);
 
             await HandleConcurrencyExceptionAsync(ex.Entries);
-            await UpdateAzuraCastStationAsync(guildId, station, stationId, apiKey, updateLastSkipTime, updateLastRequestTime);
+            await UpdateAzuraCastStationAsync(guildId, currStationId, newStationId, apiKey, updateLastSkipTime, updateLastRequestTime);
 
             _logger.DatabaseConcurrencyResolved();
         }

--- a/src/AzzyBot.Data/Services/DbActions.cs
+++ b/src/AzzyBot.Data/Services/DbActions.cs
@@ -521,7 +521,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         }
     }
 
-    public async Task UpdateAzuraCastChecksAsync(ulong guildId, bool? serverStatus = null, bool? updates = null, bool? changelog = null, int? updateNotificationCounter = null, bool? lastUpdateCheck = null, bool? lastServerStatusCheck = null)
+    public async Task UpdateAzuraCastChecksAsync(ulong guildId, bool? serverStatus = null, bool? updates = null, bool? changelog = null, int? updateNotificationCounter = null, bool updateLastUpdateCheck = false, bool updateLastServerStatusCheck = false)
     {
         await using AzzyDbContext dbContext = _dbContextFactory.CreateDbContext();
 
@@ -547,10 +547,10 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         if (updateNotificationCounter.HasValue)
             checks.UpdateNotificationCounter = updateNotificationCounter.Value;
 
-        if (lastUpdateCheck.HasValue)
+        if (updateLastUpdateCheck)
             checks.LastUpdateCheck = DateTimeOffset.UtcNow;
 
-        if (lastServerStatusCheck.HasValue)
+        if (updateLastServerStatusCheck)
             checks.LastServerStatusCheck = DateTimeOffset.UtcNow;
 
         dbContext.AzuraCastChecks.Update(checks);
@@ -564,7 +564,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
             _logger.DatabaseConcurrencyException(ex);
 
             await HandleConcurrencyExceptionAsync(ex.Entries);
-            await UpdateAzuraCastChecksAsync(guildId, serverStatus, updates, changelog, updateNotificationCounter, lastUpdateCheck, lastServerStatusCheck);
+            await UpdateAzuraCastChecksAsync(guildId, serverStatus, updates, changelog, updateNotificationCounter, updateLastUpdateCheck, updateLastServerStatusCheck);
 
             _logger.DatabaseConcurrencyResolved();
         }
@@ -610,7 +610,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         }
     }
 
-    public async Task UpdateAzuraCastStationAsync(ulong guildId, int station, int? stationId = null, string? apiKey = null, bool? lastSkipTime = null, bool? lastRequestTime = null)
+    public async Task UpdateAzuraCastStationAsync(ulong guildId, int station, int? stationId = null, string? apiKey = null, bool updateLastSkipTime = false, bool updateLastRequestTime = false)
     {
         await using AzzyDbContext dbContext = _dbContextFactory.CreateDbContext();
 
@@ -630,10 +630,10 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
         if (!string.IsNullOrEmpty(apiKey))
             azuraStation.ApiKey = Crypto.Encrypt(apiKey);
 
-        if (lastSkipTime.HasValue)
+        if (updateLastSkipTime)
             azuraStation.LastSkipTime = DateTimeOffset.UtcNow;
 
-        if (lastRequestTime.HasValue)
+        if (updateLastRequestTime)
             azuraStation.LastRequestTime = DateTimeOffset.UtcNow.AddSeconds(16);
 
         dbContext.AzuraCastStations.Update(azuraStation);
@@ -647,7 +647,7 @@ public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyD
             _logger.DatabaseConcurrencyException(ex);
 
             await HandleConcurrencyExceptionAsync(ex.Entries);
-            await UpdateAzuraCastStationAsync(guildId, station, stationId, apiKey, lastSkipTime, lastRequestTime);
+            await UpdateAzuraCastStationAsync(guildId, station, stationId, apiKey, updateLastSkipTime, updateLastRequestTime);
 
             _logger.DatabaseConcurrencyResolved();
         }

--- a/src/AzzyBot.Data/Services/DbActions.cs
+++ b/src/AzzyBot.Data/Services/DbActions.cs
@@ -7,6 +7,7 @@ using AzzyBot.Core.Logging;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Extensions;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Entities;
 
@@ -17,7 +18,7 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Data.Services;
 
-public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyDbContext> dbContextFactory)
+public sealed class DbActions(ILogger<DbActions> logger, IDbContextFactory<AzzyDbContext> dbContextFactory) : IDbActions
 {
     private readonly ILogger<DbActions> _logger = logger;
     private readonly IDbContextFactory<AzzyDbContext> _dbContextFactory = dbContextFactory;

--- a/src/AzzyBot.Data/Services/DbMaintenance.cs
+++ b/src/AzzyBot.Data/Services/DbMaintenance.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/AzzyBot.Data/Services/DbMaintenance.cs
+++ b/src/AzzyBot.Data/Services/DbMaintenance.cs
@@ -21,7 +21,7 @@ public sealed class DbMaintenance(ILogger<DbMaintenance> logger, IDbActions dbAc
         _logger.DatabaseOrphanedGuildsStart();
 
         IEnumerable<ulong> removedGuilds = await _dbActions.DeleteGuildsAsync(guilds);
-        await _dbActions.UpdateAzzyBotAsync(lastDatabaseCleanup: true);
+        await _dbActions.UpdateAzzyBotAsync(updateLastDatabaseCleanup: true);
 
         _logger.DatabaseOrphanedGuildsComplete(removedGuilds.Count());
     }

--- a/src/AzzyBot.Data/Services/DbMaintenance.cs
+++ b/src/AzzyBot.Data/Services/DbMaintenance.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using AzzyBot.Core.Logging;
+using AzzyBot.Data.Services.Interfaces;
 
 using DSharpPlus.Entities;
 
@@ -10,10 +11,10 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Data.Services;
 
-public sealed class DbMaintenance(ILogger<DbMaintenance> logger, DbActions dbActions)
+public sealed class DbMaintenance(ILogger<DbMaintenance> logger, IDbActions dbActions) : IDbMaintenance
 {
     private readonly ILogger<DbMaintenance> _logger = logger;
-    private readonly DbActions _dbActions = dbActions;
+    private readonly IDbActions _dbActions = dbActions;
 
     public async Task CleanupLeftoverGuildsAsync(IAsyncEnumerable<DiscordGuild> guilds)
     {

--- a/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
+++ b/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
+++ b/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using AzzyBot.Data.Entities;
+
 using DSharpPlus.Entities;
 
 namespace AzzyBot.Data.Services.Interfaces;
@@ -33,7 +35,7 @@ public interface IDbActions
     Task UpdateAzuraCastAsync(ulong guildId, Uri? baseUrl = null, string? apiKey = null, bool? isOnline = null);
     Task UpdateAzuraCastChecksAsync(ulong guildId, bool? serverStatus = null, bool? updates = null, bool? changelog = null, int? updateNotificationCounter = null, bool updateLastUpdateCheck = false, bool updateLastServerStatusCheck = false);
     Task UpdateAzuraCastPreferencesAsync(ulong guildId, ulong? instanceAdminGroup = null, ulong? notificationId = null, ulong? outagesId = null);
-    Task UpdateAzuraCastStationAsync(ulong guildId, int station, int? stationId = null, string? apiKey = null, bool updateLastSkipTime = false, bool updateLastRequestTime = false);
+    Task UpdateAzuraCastStationAsync(ulong guildId, int currStationId, int? newStationId = null, string? apiKey = null, bool updateLastSkipTime = false, bool updateLastRequestTime = false);
     Task UpdateAzuraCastStationChecksAsync(ulong guildId, int stationId, bool? fileChanges = null, bool updateLastFileChangesCheck = false);
     Task UpdateAzuraCastStationPreferencesAsync(ulong guildId, int stationId, ulong? stationAdminGroup = null, ulong? stationDjGroup = null, ulong? fileUploadId = null, ulong? nowPlayingEmbedChannelId = null, ulong? nowPlayingEmbedMessageId = null, ulong? requestId = null, string? fileUploadPath = null, bool? playlist = null);
     Task UpdateAzzyBotAsync(bool updateLastDatabaseCleanup = false, bool updateLastGuildReminder = false, bool updateLastUpdateCheck = false);

--- a/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
+++ b/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
@@ -34,10 +34,10 @@ public interface IDbActions
     Task UpdateAzuraCastChecksAsync(ulong guildId, bool? serverStatus = null, bool? updates = null, bool? changelog = null, int? updateNotificationCounter = null, bool updateLastUpdateCheck = false, bool updateLastServerStatusCheck = false);
     Task UpdateAzuraCastPreferencesAsync(ulong guildId, ulong? instanceAdminGroup = null, ulong? notificationId = null, ulong? outagesId = null);
     Task UpdateAzuraCastStationAsync(ulong guildId, int station, int? stationId = null, string? apiKey = null, bool updateLastSkipTime = false, bool updateLastRequestTime = false);
-    Task UpdateAzuraCastStationChecksAsync(ulong guildId, int stationId, bool? fileChanges = null, bool? lastFileChangesCheck = null);
+    Task UpdateAzuraCastStationChecksAsync(ulong guildId, int stationId, bool? fileChanges = null, bool updateLastFileChangesCheck = false);
     Task UpdateAzuraCastStationPreferencesAsync(ulong guildId, int stationId, ulong? stationAdminGroup = null, ulong? stationDjGroup = null, ulong? fileUploadId = null, ulong? nowPlayingEmbedChannelId = null, ulong? nowPlayingEmbedMessageId = null, ulong? requestId = null, string? fileUploadPath = null, bool? playlist = null);
-    Task UpdateAzzyBotAsync(bool? lastDatabaseCleanup = null, bool? lastGuildReminder = null, bool? lastUpdateCheck = null);
-    Task UpdateGuildAsync(ulong guildId, bool? lastPermissionCheck = null, DateTimeOffset? reminderLeaveDate = null, bool? legalsAccepted = null);
+    Task UpdateAzzyBotAsync(bool updateLastDatabaseCleanup = false, bool updateLastGuildReminder = false, bool updateLastUpdateCheck = false);
+    Task UpdateGuildAsync(ulong guildId, bool updateLastPermissionCheck = false, DateTimeOffset? reminderLeaveDate = null, bool? legalsAccepted = null);
     Task UpdateGuildsLegalsAsync();
     Task UpdateGuildPreferencesAsync(ulong guildId, ulong? adminRoleId = null, ulong? adminNotifyChannelId = null);
     Task UpdateMusicStreamingAsync(ulong guildId, ulong? nowPlayingEmbedChannelId = null, ulong? nowPlayingEmbedMessageId = null, int? volume = null);

--- a/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
+++ b/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AzzyBot.Data.Entities;
+using DSharpPlus.Entities;
+
+namespace AzzyBot.Data.Services.Interfaces;
+
+public interface IDbActions
+{
+    Task CreateAzuraCastAsync(ulong guildId, Uri baseUrl, string apiKey, ulong instanceAdminGroup, ulong notificationId, ulong outagesId, bool serverStatus, bool updates, bool changelog);
+    Task CreateAzuraCastStationAsync(ulong guildId, int stationId, ulong stationAdminGroup, ulong requestsId, bool showPlaylist, bool fileChanges, ulong? fileUploadId = null, string? fileUploadPath = null, string? apiKey = null, ulong? stationDjGroup = null);
+    Task CreateAzuraCastStationRequestAsync(ulong guildId, int stationId, string songId, bool isInternal = false);
+    Task CreateGuildAsync(ulong guildId);
+    Task<IEnumerable<DiscordGuild>> CreateGuildsAsync(IReadOnlyDictionary<ulong, DiscordGuild> guilds);
+    Task CreateMusicStreamingAsync(ulong guildId, ulong nowPlayingEmbedChannelId = 0, ulong nowPlayingEmbedMessageId = 0, int volume = 50);
+    Task DeleteAzuraCastAsync(ulong guildId);
+    Task DeleteAzuraCastStationAsync(int stationId);
+    Task DeleteGuildAsync(ulong guildId);
+    Task<IEnumerable<ulong>> DeleteGuildsAsync(IAsyncEnumerable<DiscordGuild> guilds);
+    Task DeleteMusicStreamingAsync(ulong guildId);
+    Task<AzuraCastEntity?> ReadAzuraCastAsync(ulong guildId, bool loadChecks = false, bool loadPrefs = false, bool loadStations = false, bool loadStationChecks = false, bool loadStationPrefs = false, bool loadGuild = false);
+    Task<IReadOnlyList<AzuraCastEntity>> ReadAzuraCastsAsync(bool loadChecks = false, bool loadPrefs = false, bool loadStations = false, bool loadStationChecks = false, bool loadStationPrefs = false, bool loadGuild = false);
+    Task<AzuraCastStationEntity?> ReadAzuraCastStationAsync(ulong guildId, int stationId, bool loadChecks = false, bool loadPrefs = false, bool loadRequests = false, bool loadAzuraCast = false, bool loadAzuraCastPrefs = false);
+    Task<AzuraCastStationPreferencesEntity?> ReadAzuraCastStationPreferencesAsync(ulong guildId, int stationId, bool loadStation = false);
+    Task<int> ReadAzuraCastStationRequestsCountAsync(ulong guildId, int stationId);
+    Task<AzzyBotEntity?> ReadAzzyBotAsync();
+    Task<GuildEntity?> ReadGuildAsync(ulong guildId, bool loadEverything = false);
+    Task<IReadOnlyList<GuildEntity>> ReadGuildsAsync(bool loadGuildPrefs = false, bool loadEverything = false);
+    Task<GuildPreferencesEntity?> ReadGuildPreferencesAsync(ulong guildId);
+    Task<MusicStreamingEntity?> ReadMusicStreamingAsync(ulong guildId, bool loadGuild = false);
+    Task<IReadOnlyList<MusicStreamingEntity>> ReadMusicStreamingAsync(bool loadGuild = false);
+    Task UpdateAzuraCastAsync(ulong guildId, Uri? baseUrl = null, string? apiKey = null, bool? isOnline = null);
+    Task UpdateAzuraCastChecksAsync(ulong guildId, bool? serverStatus = null, bool? updates = null, bool? changelog = null, int? updateNotificationCounter = null, bool? lastUpdateCheck = null, bool? lastServerStatusCheck = null);
+    Task UpdateAzuraCastPreferencesAsync(ulong guildId, ulong? instanceAdminGroup = null, ulong? notificationId = null, ulong? outagesId = null);
+    Task UpdateAzuraCastStationAsync(ulong guildId, int station, int? stationId = null, string? apiKey = null, bool? lastSkipTime = null, bool? lastRequestTime = null);
+    Task UpdateAzuraCastStationChecksAsync(ulong guildId, int stationId, bool? fileChanges = null, bool? lastFileChangesCheck = null);
+    Task UpdateAzuraCastStationPreferencesAsync(ulong guildId, int stationId, ulong? stationAdminGroup = null, ulong? stationDjGroup = null, ulong? fileUploadId = null, ulong? nowPlayingEmbedChannelId = null, ulong? nowPlayingEmbedMessageId = null, ulong? requestId = null, string? fileUploadPath = null, bool? playlist = null);
+    Task UpdateAzzyBotAsync(bool? lastDatabaseCleanup = null, bool? lastGuildReminder = null, bool? lastUpdateCheck = null);
+    Task UpdateGuildAsync(ulong guildId, bool? lastPermissionCheck = null, DateTimeOffset? reminderLeaveDate = null, bool? legalsAccepted = null);
+    Task UpdateGuildsLegalsAsync();
+    Task UpdateGuildPreferencesAsync(ulong guildId, ulong? adminRoleId = null, ulong? adminNotifyChannelId = null);
+    Task UpdateMusicStreamingAsync(ulong guildId, ulong? nowPlayingEmbedChannelId = null, ulong? nowPlayingEmbedMessageId = null, int? volume = null);
+}

--- a/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
+++ b/src/AzzyBot.Data/Services/Interfaces/IDbActions.cs
@@ -31,9 +31,9 @@ public interface IDbActions
     Task<MusicStreamingEntity?> ReadMusicStreamingAsync(ulong guildId, bool loadGuild = false);
     Task<IReadOnlyList<MusicStreamingEntity>> ReadMusicStreamingAsync(bool loadGuild = false);
     Task UpdateAzuraCastAsync(ulong guildId, Uri? baseUrl = null, string? apiKey = null, bool? isOnline = null);
-    Task UpdateAzuraCastChecksAsync(ulong guildId, bool? serverStatus = null, bool? updates = null, bool? changelog = null, int? updateNotificationCounter = null, bool? lastUpdateCheck = null, bool? lastServerStatusCheck = null);
+    Task UpdateAzuraCastChecksAsync(ulong guildId, bool? serverStatus = null, bool? updates = null, bool? changelog = null, int? updateNotificationCounter = null, bool updateLastUpdateCheck = false, bool updateLastServerStatusCheck = false);
     Task UpdateAzuraCastPreferencesAsync(ulong guildId, ulong? instanceAdminGroup = null, ulong? notificationId = null, ulong? outagesId = null);
-    Task UpdateAzuraCastStationAsync(ulong guildId, int station, int? stationId = null, string? apiKey = null, bool? lastSkipTime = null, bool? lastRequestTime = null);
+    Task UpdateAzuraCastStationAsync(ulong guildId, int station, int? stationId = null, string? apiKey = null, bool updateLastSkipTime = false, bool updateLastRequestTime = false);
     Task UpdateAzuraCastStationChecksAsync(ulong guildId, int stationId, bool? fileChanges = null, bool? lastFileChangesCheck = null);
     Task UpdateAzuraCastStationPreferencesAsync(ulong guildId, int stationId, ulong? stationAdminGroup = null, ulong? stationDjGroup = null, ulong? fileUploadId = null, ulong? nowPlayingEmbedChannelId = null, ulong? nowPlayingEmbedMessageId = null, ulong? requestId = null, string? fileUploadPath = null, bool? playlist = null);
     Task UpdateAzzyBotAsync(bool? lastDatabaseCleanup = null, bool? lastGuildReminder = null, bool? lastUpdateCheck = null);

--- a/src/AzzyBot.Data/Services/Interfaces/IDbMaintenance.cs
+++ b/src/AzzyBot.Data/Services/Interfaces/IDbMaintenance.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using DSharpPlus.Entities;

--- a/src/AzzyBot.Data/Services/Interfaces/IDbMaintenance.cs
+++ b/src/AzzyBot.Data/Services/Interfaces/IDbMaintenance.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using DSharpPlus.Entities;
+
+namespace AzzyBot.Data.Services.Interfaces;
+
+public interface IDbMaintenance
+{
+    Task CleanupLeftoverGuildsAsync(IAsyncEnumerable<DiscordGuild> guilds);
+}


### PR DESCRIPTION
This pull request refactors several bot command and autocomplete classes to consistently use interfaces for dependency injection instead of concrete service classes. This improves the codebase's flexibility and testability, and aligns with best practices for dependency management. Additionally, some minor code style and configuration improvements are included.

Key changes include:

**Dependency Injection Refactoring:**

* Updated constructors in command and autocomplete classes (e.g., `AdminCommands`, `AzuraCastMountAutocomplete`, `AzuraCastPlaylistAutocomplete`, `AzuraCastRequestAutocomplete`, `AzuraCastStationsAutocomplete`, `AzuraCastSystemLogAutocomplete`) to accept service interfaces (e.g., `IDbActions`, `IAzuraCastApiService`, `IDiscordBotService`) instead of concrete implementations. This also updates corresponding private fields and usages throughout these classes. [[1]](diffhunk://#diff-b1d72a438f56086006ec2bcdca92f5c69d33c321d4abe2156146e66735c8fe01L13-R20) [[2]](diffhunk://#diff-b1d72a438f56086006ec2bcdca92f5c69d33c321d4abe2156146e66735c8fe01L38-R43) [[3]](diffhunk://#diff-13d7a2cddeed58259b32e33006d7922eb06010e9d046e3235e05044057f5e1b9L1-R16) [[4]](diffhunk://#diff-13d7a2cddeed58259b32e33006d7922eb06010e9d046e3235e05044057f5e1b9L26-R33) [[5]](diffhunk://#diff-111acfdca8797bd871dec7156b991c745e77ccbc12a9ca6e8a61073f7e21128eL1-R16) [[6]](diffhunk://#diff-111acfdca8797bd871dec7156b991c745e77ccbc12a9ca6e8a61073f7e21128eL26-R32) [[7]](diffhunk://#diff-0eb8fcc68e9b7062acefdd27eac12e66b3873c901044b2bfa3da7f5cf7b34e39L1-R14) [[8]](diffhunk://#diff-0eb8fcc68e9b7062acefdd27eac12e66b3873c901044b2bfa3da7f5cf7b34e39L24-R29) [[9]](diffhunk://#diff-63aa4ebddd6547c55fc7699534004adfe1d007825a4a151eb00f80bd76a2cc95L1-R15) [[10]](diffhunk://#diff-63aa4ebddd6547c55fc7699534004adfe1d007825a4a151eb00f80bd76a2cc95L25-R31) [[11]](diffhunk://#diff-493e3b035b778e7f634a4cef05a9277cfa25bb6ec41284b9c161a827b71b8b64L6-R12)

* Replaced static references to permission wiki URLs (e.g., `AzuraCastApiService.AzuraCastPermissionsWiki`) with instance references via the injected service interface (e.g., `_azuraCast.AzuraCastPermissionsWiki`) in error messages. [[1]](diffhunk://#diff-13d7a2cddeed58259b32e33006d7922eb06010e9d046e3235e05044057f5e1b9L64-R64) [[2]](diffhunk://#diff-111acfdca8797bd871dec7156b991c745e77ccbc12a9ca6e8a61073f7e21128eL68-R68) [[3]](diffhunk://#diff-0eb8fcc68e9b7062acefdd27eac12e66b3873c901044b2bfa3da7f5cf7b34e39L115-R115) [[4]](diffhunk://#diff-0eb8fcc68e9b7062acefdd27eac12e66b3873c901044b2bfa3da7f5cf7b34e39L129-R129) [[5]](diffhunk://#diff-0eb8fcc68e9b7062acefdd27eac12e66b3873c901044b2bfa3da7f5cf7b34e39L138-R138) [[6]](diffhunk://#diff-0eb8fcc68e9b7062acefdd27eac12e66b3873c901044b2bfa3da7f5cf7b34e39L149-R156) [[7]](diffhunk://#diff-63aa4ebddd6547c55fc7699534004adfe1d007825a4a151eb00f80bd76a2cc95L70-R70) [[8]](diffhunk://#diff-63aa4ebddd6547c55fc7699534004adfe1d007825a4a151eb00f80bd76a2cc95L86-R86)

**Code Style and Configuration:**

* Added `charset = utf-8` to the `.editorconfig` file to enforce UTF-8 encoding for all files.
* Removed unnecessary BOM (byte order mark) from the start of several C# files for consistency. [[1]](diffhunk://#diff-b1d72a438f56086006ec2bcdca92f5c69d33c321d4abe2156146e66735c8fe01L1-R1) [[2]](diffhunk://#diff-13d7a2cddeed58259b32e33006d7922eb06010e9d046e3235e05044057f5e1b9L1-R16) [[3]](diffhunk://#diff-111acfdca8797bd871dec7156b991c745e77ccbc12a9ca6e8a61073f7e21128eL1-R16) [[4]](diffhunk://#diff-0eb8fcc68e9b7062acefdd27eac12e66b3873c901044b2bfa3da7f5cf7b34e39L1-R14) [[5]](diffhunk://#diff-63aa4ebddd6547c55fc7699534004adfe1d007825a4a151eb00f80bd76a2cc95L1-R15)