### PR TITLE
Rename AzuraCastStationAutocomplete and add new API autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@
 ### Improvements
 - The bot now also sends a welcome notification to the first channel it can see when it's added to a server
   - This is in addition to the DM sent to the server owner and is intended to make sure that the bot can reach the users in some way
-- The command `config add-azuracast-station` was improved by adding an autocomplete of only display existing stations on the server to reduce issues
+- The command `config add-azuracast-station` was improved by adding autocomplete that displays only existing stations from the server to reduce issues
 - We now log the full exception when the ChecksFailedException occurs to be able to see what the issue is
 
 ### Fixes
+- A bug was fixed regarding searches in autocompletes for stations
 - An `ArgumentException` could appear when you have multiple stations using the same discord roles
 
 ### Development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Improvements
 - The bot now also sends a welcome notification to the first channel it can see when it's added to a server
   - This is in addition to the DM sent to the server owner and is intended to make sure that the bot can reach the users in some way
+- The command `config add-azuracast-station` was improved by adding an autocomplete of only display existing stations on the server to reduce issues
 - We now log the full exception when the ChecksFailedException occurs to be able to see what the issue is
 
 ### Fixes

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsInDbAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsInDbAutocomplete.cs
@@ -22,9 +22,9 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastStationsinDbAutocomplete(ILogger<AzuraCastStationsinDbAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastStationsInDbAutocomplete(ILogger<AzuraCastStationsInDbAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
-    private readonly ILogger<AzuraCastStationsinDbAutocomplete> _logger = logger;
+    private readonly ILogger<AzuraCastStationsInDbAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
     private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;
@@ -77,7 +77,7 @@ public sealed class AzuraCastStationsinDbAutocomplete(ILogger<AzuraCastStationsi
                 return results;
             }
 
-            if (!string.IsNullOrWhiteSpace(search) && azuraStation.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(search) && !azuraStation.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
                 continue;
 
             AzuraAdminStationConfigRecord? config = await _azuraCast.GetStationAdminConfigAsync(baseUrl, adminApiKey, station.StationId);

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsInDbAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsInDbAutocomplete.cs
@@ -22,9 +22,9 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastStationsAutocomplete(ILogger<AzuraCastStationsAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastStationsinDbAutocomplete(ILogger<AzuraCastStationsinDbAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
-    private readonly ILogger<AzuraCastStationsAutocomplete> _logger = logger;
+    private readonly ILogger<AzuraCastStationsinDbAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
     private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
     private readonly IDbActions _dbActions = dbActions;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsOnlineAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsOnlineAutocomplete.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using AzzyBot.Bot.Services.Modules.Interfaces;
+using AzzyBot.Bot.Utilities.Records.AzuraCast;
+using AzzyBot.Core.Utilities;
+using AzzyBot.Core.Utilities.Encryption;
+using AzzyBot.Core.Utilities.Enums;
+using AzzyBot.Data.Entities;
+using AzzyBot.Data.Logging;
+using AzzyBot.Data.Services.Interfaces;
+
+using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Commands.Processors.SlashCommands.ArgumentModifiers;
+using DSharpPlus.Entities;
+
+using Microsoft.Extensions.Logging;
+
+namespace AzzyBot.Bot.Commands.Autocompletes;
+
+public sealed class AzuraCastStationsOnlineAutocomplete(ILogger<AzuraCastStationsOnlineAutocomplete> logger, IAzuraCastApiService azuraCastApi, IDbActions dbActions) : IAutoCompleteProvider
+{
+    private readonly ILogger<AzuraCastStationsOnlineAutocomplete> _logger = logger;
+    private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
+    private readonly IDbActions _dbActions = dbActions;
+
+    public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        ArgumentNullException.ThrowIfNull(context.Guild);
+
+        AzuraCastEntity? azuraCast = await _dbActions.ReadAzuraCastAsync(context.Guild.Id, loadStations: true);
+        if (azuraCast is null)
+        {
+            _logger.DatabaseAzuraCastNotFound(context.Guild.Id);
+            return [];
+        }
+        else if (!azuraCast.IsOnline)
+        {
+            return [];
+        }
+
+        Uri baseUrl = new(Crypto.Decrypt(azuraCast.BaseUrl));
+        string apiKey = Crypto.Decrypt(azuraCast.AdminApiKey);
+        IEnumerable<AzuraCastStationEntity> stationsInDb = azuraCast.Stations;
+        IEnumerable<AzuraAdminStationConfigRecord>? stationsOnline = await _azuraCast.GetStationsAdminConfigAsync(baseUrl, apiKey);
+        if (stationsOnline is null)
+            return [];
+
+        IEnumerable<AzuraAdminStationConfigRecord> stations = stationsOnline.Where(o => !stationsInDb.Any(s => s.StationId == o.Id));
+        string? search = context.UserInput;
+        List<DiscordAutoCompleteChoice> results = new(25);
+        foreach (AzuraAdminStationConfigRecord station in stations)
+        {
+            if (results.Count is 25)
+                break;
+
+            if (!string.IsNullOrWhiteSpace(search) && station.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            results.Add(new DiscordAutoCompleteChoice($"{station.Name} ({Misc.GetReadableBool(station.IsEnabled, ReadableBool.EnabledDisabled)})", station.Id));
+        }
+
+        return results;
+    }
+}

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsOnlineAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsOnlineAutocomplete.cs
@@ -57,7 +57,7 @@ public sealed class AzuraCastStationsOnlineAutocomplete(ILogger<AzuraCastStation
             if (results.Count is 25)
                 break;
 
-            if (!string.IsNullOrWhiteSpace(search) && station.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrWhiteSpace(search) && !station.Name.Contains(search, StringComparison.OrdinalIgnoreCase))
                 continue;
 
             results.Add(new DiscordAutoCompleteChoice($"{station.Name} ({Misc.GetReadableBool(station.IsEnabled, ReadableBool.EnabledDisabled)})", station.Id));

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzzyHelpAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzzyHelpAutocomplete.cs
@@ -26,14 +26,13 @@ public sealed class AzzyHelpAutocomplete(IOptions<AzzyBotSettings> settings) : I
         ArgumentNullException.ThrowIfNull(context.Guild);
         ArgumentNullException.ThrowIfNull(context.Member);
 
-        string? search = context.UserInput;
-
         IEnumerable<DiscordUser> botOwners = context.Client.CurrentApplication.Owners;
         ulong guildId = context.Guild.Id;
         DiscordMember member = context.Member;
 
         bool adminServer = botOwners.Any(u => u.Id == context.User.Id && member.Permissions.HasPermission(DiscordPermission.Administrator) && guildId == _settings.ServerId);
         bool approvedDebug = guildId == _settings.ServerId;
+        string? search = context.UserInput;
         List<DiscordAutoCompleteChoice> results = new(25);
         foreach (List<AzzyHelpRecord> kvp in AzzyHelp.GetAllCommands(context.Extension.Commands, adminServer, approvedDebug, member).Select(k => k.Value))
         {

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzzyViewLogsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzzyViewLogsAutocomplete.cs
@@ -18,9 +18,8 @@ public sealed class AzzyViewLogsAutocomplete : IAutoCompleteProvider
     {
         ArgumentNullException.ThrowIfNull(context);
 
-        List<DiscordAutoCompleteChoice> results = new(25);
         string? search = context.UserInput;
-
+        List<DiscordAutoCompleteChoice> results = new(25);
         foreach (string file in FileOperations.GetFilesInDirectory("Logs").OrderByDescending(static f => f))
         {
             if (results.Count is 25)

--- a/src/AzzyBot.Bot/Commands/Autocompletes/GuildsAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/GuildsAutocomplete.cs
@@ -28,10 +28,9 @@ public sealed class GuildsAutocomplete(IOptions<AzzyBotSettings> settings, IDisc
         if (guilds.Count is 0)
             return ValueTask.FromResult(new List<DiscordAutoCompleteChoice>(1).AsEnumerable());
 
-        string? search = context.UserInput;
-
-        List<DiscordAutoCompleteChoice> results = new(25);
         string commandName = context.Command.Name;
+        string? search = context.UserInput;
+        List<DiscordAutoCompleteChoice> results = new(25);
         foreach (DiscordGuild guild in guilds.Values)
         {
             if (results.Count is 25)

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -61,7 +61,7 @@ public sealed class AzuraCastCommands
         public async ValueTask ExportPlaylistsAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to export the playlists."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station of which you want to export the playlists."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("Choose if you want to export the playlist in M3U or PLS format."), SlashChoiceProvider<AzuraExportPlaylistProvider>] string format,
             [Description("Select the playlist you want to export."), SlashAutoCompleteProvider<AzuraCastPlaylistAutocomplete>] int? userPlaylist = null
         )
@@ -152,7 +152,7 @@ public sealed class AzuraCastCommands
         public async ValueTask ForceApiPermissionCheckAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to check the api key."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int? station = null
+            [Description("The station of which you want to check the api key."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int? station = null
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -192,7 +192,7 @@ public sealed class AzuraCastCommands
         public async ValueTask ForceCacheRefreshAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to refresh the cache."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int? station = null
+            [Description("The station of which you want to refresh the cache."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int? station = null
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -347,7 +347,7 @@ public sealed class AzuraCastCommands
         public async ValueTask StartStationAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to start."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station
+            [Description("The station you want to start."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -391,7 +391,7 @@ public sealed class AzuraCastCommands
         public async ValueTask SetStationNowPlayingEmbedAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to set the now playing embed for."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station you want to set the now playing embed for."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The channel where the now playing embed should be sent.")] DiscordChannel? channel = null
         )
         {
@@ -453,7 +453,7 @@ public sealed class AzuraCastCommands
         public async ValueTask StopStationAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to stop."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station
+            [Description("The station you want to stop."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -518,7 +518,7 @@ public sealed class AzuraCastCommands
         public async ValueTask ToggleSongRequestsAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to toggle song requests for."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station
+            [Description("The station you want to toggle song requests for."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -632,7 +632,7 @@ public sealed class AzuraCastCommands
         public async ValueTask AddInternalSongRequestAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to add the song request."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station of which you want to add the song request."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The song you want to request."), SlashAutoCompleteProvider<AzuraCastRequestAutocomplete>] string song
         )
         {
@@ -707,7 +707,7 @@ public sealed class AzuraCastCommands
         public async ValueTask DeleteSongRequestAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to delete the song request."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station of which you want to delete the song request."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The request id of the song you want to delete."), SlashAutoCompleteProvider<AzuraCastRequestAutocomplete>] int requestId = 0
         )
         {
@@ -750,7 +750,7 @@ public sealed class AzuraCastCommands
         public async ValueTask SkipSongAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to skip the song."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station
+            [Description("The station of which you want to skip the song."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -806,7 +806,7 @@ public sealed class AzuraCastCommands
         public async ValueTask SwitchPlaylistAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to switch the playlist."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station of which you want to switch the playlist."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The playlist you want to switch to."), SlashAutoCompleteProvider<AzuraCastPlaylistAutocomplete>] int playlistId,
             [Description("Choose if you want to disable all other active playlists from the station. Defaults to Yes."), SlashChoiceProvider<BooleanYesNoStateProvider>] int removeOld = 0
         )
@@ -875,7 +875,7 @@ public sealed class AzuraCastCommands
         public async ValueTask GetSongHistoryAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to see the song history."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station of which you want to see the song history."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The date of which you want to see the song history in the format YYYY-MM-DD.")] string? date = null
         )
         {
@@ -957,7 +957,7 @@ public sealed class AzuraCastCommands
         public async ValueTask GetSongsInPlaylistAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to see the songs in the playlist."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station of which you want to see the songs in the playlist."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The playlist you want to see the songs from."), SlashAutoCompleteProvider<AzuraCastPlaylistAutocomplete>] int playlistId
         )
         {
@@ -1031,7 +1031,7 @@ public sealed class AzuraCastCommands
         public async ValueTask GetNowPlayingAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to see what's played."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station
+            [Description("The station of which you want to see what's played."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -1128,7 +1128,7 @@ public sealed class AzuraCastCommands
         public async ValueTask SearchSongAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to search for a song."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station of which you want to search for a song."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The song you want to search for."), SlashAutoCompleteProvider<AzuraCastRequestAutocomplete>] string song
         )
         {
@@ -1273,7 +1273,7 @@ public sealed class AzuraCastCommands
         public async ValueTask UploadFilesAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to upload the file to."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station you want to upload the file to."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The file you want to upload.")] DiscordAttachment file
         )
         {

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -61,7 +61,7 @@ public sealed class AzuraCastCommands
         public async ValueTask ExportPlaylistsAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to export the playlists."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station of which you want to export the playlists."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("Choose if you want to export the playlist in M3U or PLS format."), SlashChoiceProvider<AzuraExportPlaylistProvider>] string format,
             [Description("Select the playlist you want to export."), SlashAutoCompleteProvider<AzuraCastPlaylistAutocomplete>] int? userPlaylist = null
         )
@@ -152,7 +152,7 @@ public sealed class AzuraCastCommands
         public async ValueTask ForceApiPermissionCheckAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to check the api key."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int? station = null
+            [Description("The station of which you want to check the api key."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int? station = null
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -192,7 +192,7 @@ public sealed class AzuraCastCommands
         public async ValueTask ForceCacheRefreshAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to refresh the cache."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int? station = null
+            [Description("The station of which you want to refresh the cache."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int? station = null
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -347,7 +347,7 @@ public sealed class AzuraCastCommands
         public async ValueTask StartStationAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to start."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
+            [Description("The station you want to start."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -391,7 +391,7 @@ public sealed class AzuraCastCommands
         public async ValueTask SetStationNowPlayingEmbedAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to set the now playing embed for."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station you want to set the now playing embed for."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The channel where the now playing embed should be sent.")] DiscordChannel? channel = null
         )
         {
@@ -453,7 +453,7 @@ public sealed class AzuraCastCommands
         public async ValueTask StopStationAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to stop."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
+            [Description("The station you want to stop."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -518,7 +518,7 @@ public sealed class AzuraCastCommands
         public async ValueTask ToggleSongRequestsAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to toggle song requests for."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
+            [Description("The station you want to toggle song requests for."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -632,7 +632,7 @@ public sealed class AzuraCastCommands
         public async ValueTask AddInternalSongRequestAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to add the song request."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station of which you want to add the song request."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The song you want to request."), SlashAutoCompleteProvider<AzuraCastRequestAutocomplete>] string song
         )
         {
@@ -707,7 +707,7 @@ public sealed class AzuraCastCommands
         public async ValueTask DeleteSongRequestAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to delete the song request."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station of which you want to delete the song request."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The request id of the song you want to delete."), SlashAutoCompleteProvider<AzuraCastRequestAutocomplete>] int requestId = 0
         )
         {
@@ -750,7 +750,7 @@ public sealed class AzuraCastCommands
         public async ValueTask SkipSongAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to skip the song."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
+            [Description("The station of which you want to skip the song."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -806,7 +806,7 @@ public sealed class AzuraCastCommands
         public async ValueTask SwitchPlaylistAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to switch the playlist."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station of which you want to switch the playlist."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The playlist you want to switch to."), SlashAutoCompleteProvider<AzuraCastPlaylistAutocomplete>] int playlistId,
             [Description("Choose if you want to disable all other active playlists from the station. Defaults to Yes."), SlashChoiceProvider<BooleanYesNoStateProvider>] int removeOld = 0
         )
@@ -875,7 +875,7 @@ public sealed class AzuraCastCommands
         public async ValueTask GetSongHistoryAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to see the song history."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station of which you want to see the song history."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The date of which you want to see the song history in the format YYYY-MM-DD.")] string? date = null
         )
         {
@@ -957,7 +957,7 @@ public sealed class AzuraCastCommands
         public async ValueTask GetSongsInPlaylistAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to see the songs in the playlist."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station of which you want to see the songs in the playlist."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The playlist you want to see the songs from."), SlashAutoCompleteProvider<AzuraCastPlaylistAutocomplete>] int playlistId
         )
         {
@@ -1031,7 +1031,7 @@ public sealed class AzuraCastCommands
         public async ValueTask GetNowPlayingAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to see what's played."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
+            [Description("The station of which you want to see what's played."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -1128,7 +1128,7 @@ public sealed class AzuraCastCommands
         public async ValueTask SearchSongAsync
         (
             SlashCommandContext context,
-            [Description("The station of which you want to search for a song."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station of which you want to search for a song."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The song you want to search for."), SlashAutoCompleteProvider<AzuraCastRequestAutocomplete>] string song
         )
         {
@@ -1273,7 +1273,7 @@ public sealed class AzuraCastCommands
         public async ValueTask UploadFilesAsync
         (
             SlashCommandContext context,
-            [Description("The station you want to upload the file to."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station you want to upload the file to."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The file you want to upload.")] DiscordAttachment file
         )
         {

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -247,7 +247,7 @@ public sealed class ConfigCommands
         public async ValueTask DeleteAzuraCastStationAsync
         (
             SlashCommandContext context,
-            [Description("Choose the station you want to delete."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
+            [Description("Choose the station you want to delete."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -415,7 +415,7 @@ public sealed class ConfigCommands
         public async ValueTask UpdateAzuraCastStationAsync
         (
             SlashCommandContext context,
-            [Description("Choose the station you want to modify."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("Choose the station you want to modify."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("Modify the station id.")] int? stationId = null,
             [Description("Modify the api key.")] string? apiKey = null,
             [Description("Modify the group that has the admin permissions on this station.")] DiscordRole? adminGroup = null,
@@ -494,7 +494,7 @@ public sealed class ConfigCommands
         public async ValueTask UpdateAzuraCastStationChecksAsync
         (
             SlashCommandContext context,
-            [Description("Choose the station you want to modify the checks."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("Choose the station you want to modify the checks."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("Enable or disable the check if server files have been changed. This also enables local file caching."), SlashChoiceProvider<BooleanEnableDisableStateProvider>] int fileChanges = 0
         )
         {

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -166,7 +166,7 @@ public sealed class ConfigCommands
         public async ValueTask AddAzuraCastStationAsync
         (
             SlashCommandContext context,
-            [Description("Enter the station id of your azuracast station.")] int station,
+            [Description("Enter the station id of your azuracast station."), SlashAutoCompleteProvider<AzuraCastStationsOnlineAutocomplete>] int station,
             [Description("Select the group that has the admin permissions on this station.")] DiscordRole adminGroup,
             [Description("Select a channel to get music requests when a request is not found on the server."), ChannelTypes(DiscordChannelType.Text)] DiscordChannel requestsChannel,
             [Description("Enable or disable the showing of the playlist in the nowplaying embed."), SlashChoiceProvider<BooleanEnableDisableStateProvider>] int showPlaylist,

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -247,7 +247,7 @@ public sealed class ConfigCommands
         public async ValueTask DeleteAzuraCastStationAsync
         (
             SlashCommandContext context,
-            [Description("Choose the station you want to delete."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station
+            [Description("Choose the station you want to delete."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station
         )
         {
             ArgumentNullException.ThrowIfNull(context);
@@ -415,7 +415,7 @@ public sealed class ConfigCommands
         public async ValueTask UpdateAzuraCastStationAsync
         (
             SlashCommandContext context,
-            [Description("Choose the station you want to modify."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("Choose the station you want to modify."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("Modify the station id.")] int? stationId = null,
             [Description("Modify the api key.")] string? apiKey = null,
             [Description("Modify the group that has the admin permissions on this station.")] DiscordRole? adminGroup = null,
@@ -494,7 +494,7 @@ public sealed class ConfigCommands
         public async ValueTask UpdateAzuraCastStationChecksAsync
         (
             SlashCommandContext context,
-            [Description("Choose the station you want to modify the checks."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("Choose the station you want to modify the checks."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("Enable or disable the check if server files have been changed. This also enables local file caching."), SlashChoiceProvider<BooleanEnableDisableStateProvider>] int fileChanges = 0
         )
         {

--- a/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
+++ b/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
@@ -241,7 +241,7 @@ public sealed class MusicStreamingCommands
         public async ValueTask PlayMountAsync
         (
             SlashCommandContext context,
-            [Description("The station you want play."), SlashAutoCompleteProvider<AzuraCastStationsAutocomplete>] int station,
+            [Description("The station you want play."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
             [Description("The mount point of the station."), SlashAutoCompleteProvider<AzuraCastMountAutocomplete>] int mountPoint,
             [Description("The volume which should be set. This is only respected when no music is being played.")] int volume = 50
         )

--- a/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
+++ b/src/AzzyBot.Bot/Commands/MusicStreamingCommands.cs
@@ -241,7 +241,7 @@ public sealed class MusicStreamingCommands
         public async ValueTask PlayMountAsync
         (
             SlashCommandContext context,
-            [Description("The station you want play."), SlashAutoCompleteProvider<AzuraCastStationsinDbAutocomplete>] int station,
+            [Description("The station you want play."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
             [Description("The mount point of the station."), SlashAutoCompleteProvider<AzuraCastMountAutocomplete>] int mountPoint,
             [Description("The volume which should be set. This is only respected when no music is being played.")] int volume = 50
         )

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -534,7 +534,16 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDi
 
         string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}";
 
-        return GetFromApiAsync<AzuraStationRecord>(baseUrl, endpoint, JsonSourceGen.Default.AzuraStationRecord, CreateHeader(apiKey));
+        return GetFromApiAsync(baseUrl, endpoint, JsonSourceGen.Default.AzuraStationRecord, CreateHeader(apiKey));
+    }
+
+    public Task<IEnumerable<AzuraAdminStationConfigRecord>?> GetStationsAdminConfigAsync(Uri baseUrl, string apiKey)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+
+        string endpoint = $"{AzuraApiEndpoints.Admin}/{AzuraApiEndpoints.Stations}";
+
+        return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraAdminStationConfigRecord, CreateHeader(apiKey));
     }
 
     public Task<AzuraAdminStationConfigRecord?> GetStationAdminConfigAsync(Uri baseUrl, string apiKey, int stationId)
@@ -544,7 +553,7 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDi
 
         string endpoint = $"{AzuraApiEndpoints.Admin}/{AzuraApiEndpoints.Station}/{stationId}";
 
-        return GetFromApiAsync<AzuraAdminStationConfigRecord>(baseUrl, endpoint, JsonSourceGen.Default.AzuraAdminStationConfigRecord, CreateHeader(apiKey));
+        return GetFromApiAsync(baseUrl, endpoint, JsonSourceGen.Default.AzuraAdminStationConfigRecord, CreateHeader(apiKey));
     }
 
     public Task<IEnumerable<AzuraStationHistoryItemRecord>?> GetStationHistoryAsync(Uri baseUrl, string apiKey, int stationId, in DateTimeOffset startHistory, in DateTimeOffset endHistory)

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastApiService.cs
@@ -33,6 +33,7 @@ public interface IAzuraCastApiService
     Task<IEnumerable<AzuraMediaItemRecord>?> GetSongsInPlaylistAsync(Uri baseUrl, string apiKey, int stationId, AzuraPlaylistRecord playlist);
     Task<AzuraSongDataRecord?> GetSongInfoAsync(Uri baseUrl, string apiKey, AzuraCastStationEntity station, bool online, string? uniqueId = null, string? songId = null, string? name = null, string? artist = null, string? album = null);
     Task<AzuraStationRecord?> GetStationAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<IEnumerable<AzuraAdminStationConfigRecord>?> GetStationsAdminConfigAsync(Uri baseUrl, string apiKey);
     Task<AzuraAdminStationConfigRecord?> GetStationAdminConfigAsync(Uri baseUrl, string apiKey, int stationId);
     Task<IEnumerable<AzuraStationHistoryItemRecord>?> GetStationHistoryAsync(Uri baseUrl, string apiKey, int stationId, in DateTimeOffset startHistory, in DateTimeOffset endHistory);
     Task<IEnumerable<AzuraHlsMountRecord>?> GetStationHlsMountPointsAsync(Uri baseUrl, string apiKey, int stationId);

--- a/src/AzzyBot.Bot/Utilities/JsonSourceGen.cs
+++ b/src/AzzyBot.Bot/Utilities/JsonSourceGen.cs
@@ -19,35 +19,36 @@ namespace AzzyBot.Bot.Utilities;
 [JsonSerializable(typeof(AzuraInternalRequestRecord))]
 [JsonSerializable(typeof(SerializableExceptionsRecord))]
 // Deserialization
-[JsonSerializable(typeof(AzuraAdminStationConfigRecord))] // Generic
-[JsonSerializable(typeof(AzuraErrorRecord))] // Generic
+[JsonSerializable(typeof(AzuraAdminStationConfigRecord))]
+[JsonSerializable(typeof(IEnumerable<AzuraAdminStationConfigRecord>))]
+[JsonSerializable(typeof(AzuraErrorRecord))]
 [JsonSerializable(typeof(AzuraFilesRecord))]
-[JsonSerializable(typeof(AzuraFilesDetailedRecord))] // Generic
-[JsonSerializable(typeof(IEnumerable<AzuraFilesDetailedRecord>))] // Generic
-[JsonSerializable(typeof(AzuraHardwareStatsRecord))] // Generic
+[JsonSerializable(typeof(AzuraFilesDetailedRecord))]
+[JsonSerializable(typeof(IEnumerable<AzuraFilesDetailedRecord>))]
+[JsonSerializable(typeof(AzuraHardwareStatsRecord))]
 [JsonSerializable(typeof(AzuraHlsMountRecord))]
-[JsonSerializable(typeof(IEnumerable<AzuraHlsMountRecord>))] // Generic
-[JsonSerializable(typeof(AzuraNowPlayingDataRecord))] // Generic
-[JsonSerializable(typeof(AzuraPlaylistRecord))] // Generic
-[JsonSerializable(typeof(IEnumerable<AzuraPlaylistRecord>))] // Generic
+[JsonSerializable(typeof(IEnumerable<AzuraHlsMountRecord>))]
+[JsonSerializable(typeof(AzuraNowPlayingDataRecord))]
+[JsonSerializable(typeof(AzuraPlaylistRecord))]
+[JsonSerializable(typeof(IEnumerable<AzuraPlaylistRecord>))]
 [JsonSerializable(typeof(AzuraRequestRecord))]
-[JsonSerializable(typeof(IEnumerable<AzuraRequestRecord>))] // Generic
+[JsonSerializable(typeof(IEnumerable<AzuraRequestRecord>))]
 [JsonSerializable(typeof(AzuraRequestQueueItemRecord))]
-[JsonSerializable(typeof(IEnumerable<AzuraRequestQueueItemRecord>))] // Generic
+[JsonSerializable(typeof(IEnumerable<AzuraRequestQueueItemRecord>))]
 [JsonSerializable(typeof(AzuraMediaItemRecord))]
-[JsonSerializable(typeof(IEnumerable<AzuraMediaItemRecord>))] // Generic
+[JsonSerializable(typeof(IEnumerable<AzuraMediaItemRecord>))]
 [JsonSerializable(typeof(AzuraSongDataRecord))]
 [JsonSerializable(typeof(AzuraStationHistoryItemRecord))]
-[JsonSerializable(typeof(IEnumerable<AzuraStationHistoryItemRecord>))] // Generic
+[JsonSerializable(typeof(IEnumerable<AzuraStationHistoryItemRecord>))]
 [JsonSerializable(typeof(AzuraStationListenerRecord))]
-[JsonSerializable(typeof(IEnumerable<AzuraStationListenerRecord>))] // Generic
+[JsonSerializable(typeof(IEnumerable<AzuraStationListenerRecord>))]
 [JsonSerializable(typeof(AzuraStationQueueItemDetailedRecord))]
-[JsonSerializable(typeof(IEnumerable<AzuraStationQueueItemDetailedRecord>))] // Generic
-[JsonSerializable(typeof(AzuraStationRecord))] // Generic
-[JsonSerializable(typeof(AzuraStationStatusRecord))] // Generic
-[JsonSerializable(typeof(AzuraStatusRecord))] // Generic
-[JsonSerializable(typeof(AzuraSystemLogsRecord))] // Generic
-[JsonSerializable(typeof(AzuraSystemLogRecord))] // Generic
+[JsonSerializable(typeof(IEnumerable<AzuraStationQueueItemDetailedRecord>))]
+[JsonSerializable(typeof(AzuraStationRecord))]
+[JsonSerializable(typeof(AzuraStationStatusRecord))]
+[JsonSerializable(typeof(AzuraStatusRecord))]
+[JsonSerializable(typeof(AzuraSystemLogsRecord))]
+[JsonSerializable(typeof(AzuraSystemLogRecord))]
 [JsonSerializable(typeof(AzuraUpdateRecord))]
 [JsonSerializable(typeof(AzuraUpdateErrorRecord))]
 [JsonSerializable(typeof(List<AzzyUpdateRecord>))]

--- a/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraAdminStationConfigRecord.cs
+++ b/src/AzzyBot.Bot/Utilities/Records/AzuraCast/AzuraAdminStationConfigRecord.cs
@@ -8,6 +8,12 @@ namespace AzzyBot.Bot.Utilities.Records.AzuraCast;
 public sealed record AzuraAdminStationConfigRecord
 {
     /// <summary>
+    /// Station ID
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required int Id { get; set; }
+
+    /// <summary>
     /// The full display name of the station.
     /// </summary>
     [JsonPropertyName("name")]


### PR DESCRIPTION
This pull request improves the autocomplete functionality for AzuraCast station selection in commands by ensuring only stations already configured in the server's database are shown, reducing user errors. It also introduces a new autocomplete provider for stations that are online but not yet added, and includes several minor fixes and code cleanups related to autocomplete logic.

**Improvements to station autocomplete and command usage:**

* The `AzuraCastStationsAutocomplete` provider was renamed and refactored to `AzuraCastStationsInDbAutocomplete`, now only suggesting stations that exist in the server's database, and all relevant command parameters were updated to use this new provider. [[1]](diffhunk://#diff-f1fdab185190ddc4d99e3b5e30e8384487a59f35ceecd5066e04533ac9ac4d80L25-R27) [[2]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL64-R64) [[3]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL155-R155) [[4]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL195-R195) [[5]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL350-R350) [[6]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL394-R394) [[7]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL456-R456) [[8]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL521-R521) [[9]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL635-R635) [[10]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL710-R710) [[11]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL753-R753) [[12]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL809-R809) [[13]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL878-R878) [[14]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL960-R960) [[15]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL1034-R1034) [[16]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL1131-R1131) [[17]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL1276-R1276)
* Added a new autocomplete provider, `AzuraCastStationsOnlineAutocomplete`, which suggests stations that are online but not yet configured in the server, supporting future enhancements.

**Bug fixes:**

* Fixed a bug in the station autocomplete search logic that previously included incorrect matches.
* Fixed a bug related to autocomplete searches for stations, as noted in the changelog.

**Changelog and minor code cleanups:**

* Updated the changelog to reflect the new autocomplete improvements and bug fixes.
* Minor code cleanups and reordering of variable declarations in various autocomplete providers for consistency. [[1]](diffhunk://#diff-f0290b3d63e4581c07c004ddfbb6e1a357a7ad5aa61fe69d1863b729513b69eaL29-R35) [[2]](diffhunk://#diff-074d1aaf74a6c0dfa3e2588a23133de003939c2d2c686cc5cdbeb363fac40badL21-R22) [[3]](diffhunk://#diff-d2c366dda609c968c0fd892be03c970060590bd3d92a40cb7e709d0dda432d00R31-L34)