### PR TITLE
Re-enable QUIC support in Docker images and fix build issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Upgraded docker images to Ubuntu 26.04 resolute
 
 ### Improvements
-- Re-enabled HTTP/3 support after implementing several packages into the dockerfiles
+- Re-enabled HTTP/3 support after implementing several packages in the Dockerfiles
 - The bot now also sends a welcome notification to the first channel it can see when it's added to a server
   - This is in addition to the DM sent to the server owner and is intended to make sure that the bot can reach the users in some way
 - The command `config add-azuracast-station` was improved by adding autocomplete that displays only existing stations from the server to reduce issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Upgraded docker images to Ubuntu 26.04 resolute
 
 ### Improvements
+- Re-enabled HTTP/3 support after implementing several packages into the dockerfiles
 - The bot now also sends a welcome notification to the first channel it can see when it's added to a server
   - This is in addition to the DM sent to the server owner and is intended to make sure that the bot can reach the users in some way
 - The command `config add-azuracast-station` was improved by adding autocomplete that displays only existing stations from the server to reduce issues
@@ -15,6 +16,7 @@
 
 ### Development
 - Abstracted all relevant services to interfaces to follow dependency inversion principles
+- Extended the command `debug webservice-tests` to show more information about the current request and response
 - JSON types in `AzuraCastApiService.cs` are known at compile time instead of runtime
 - Reencoded all source files to UTF-8 without BOM
 - Renamed `Startup.cs` to `Program.cs` to align with .NET conventions

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <!-- Development stuff -->
   <PropertyGroup>
@@ -59,12 +59,6 @@
     <RepositoryUrl>https://github.com/Sella-GH/AzzyBot</RepositoryUrl>
     <Version>2.10.0</Version>
   </PropertyGroup>
-  
-  <!-- Runtimeconfig settings -->
-  <ItemGroup>
-     <!-- Exclude HTTP/3 on purpose until .NET fixes it -->
-    <RuntimeHostConfigurationOption Value="false" Include="System.Net.SocketsHttpHandler.Http3Support" />
-  </ItemGroup>
 
   <PropertyGroup>
     <!-- JIT Settings -->

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -28,7 +28,7 @@ USER root
 
 # Upgrade internal tools and packages first
 RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/packages-microsoft-prod.deb \
-  && apt-get update \
+  apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends iputils-ping libgssapi-krb5-2 libzstd-dev \
   && apt-get install -y --no-install-recommends /packages-microsoft-prod.deb \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -29,7 +29,6 @@ USER root
 # Upgrade internal tools and packages first
 RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/tmp/packages-microsoft-prod.deb \
   apt-get update \
-  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends ca-certificates gnupg \
   && dpkg -i /tmp/packages-microsoft-prod.deb \
   && apt-get update \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -27,11 +27,14 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0-resolute AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/packages-microsoft-prod.deb \
+RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/tmp/packages-microsoft-prod.deb \
   apt-get update \
   && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends ca-certificates gnupg \
+  && dpkg -i /tmp/packages-microsoft-prod.deb \
+  && apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends iputils-ping libgssapi-krb5-2 libzstd-dev \
-  && apt-get install -y --no-install-recommends /packages-microsoft-prod.deb \
   && apt-get install -y --no-install-recommends libmsquic libxdp1 libnl-3-200 libnl-route-3-200 \
   && apt-get autoremove --purge -y \
   && apt-get clean -y \

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:labs
 
-# BUILD IMAGE
+# --- BUILD IMAGE ---
 FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
 USER root
 
@@ -20,14 +20,19 @@ RUN dotnet restore ./src/AzzyBot.Bot/AzzyBot.Bot.csproj --configfile ./Nuget.con
   && dotnet build ./src/AzzyBot.Bot/AzzyBot.Bot.csproj -c $CONFIG --no-incremental --no-restore --no-self-contained --ucr \
   && dotnet publish ./src/AzzyBot.Bot/AzzyBot.Bot.csproj -c $CONFIG --no-build --no-restore --no-self-contained -o out --ucr
 
-# RUNNER IMAGE
+ADD https://packages.microsoft.com/config/ubuntu/26.04/packages-microsoft-prod.deb /packages-microsoft-prod.deb
+
+# --- RUNNER IMAGE ---
 FROM mcr.microsoft.com/dotnet/runtime:10.0-resolute AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN apt-get update \
+RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/packages-microsoft-prod.deb \
+  && apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends iputils-ping libgssapi-krb5-2 libzstd-dev \
+  && apt-get install -y --no-install-recommends /packages-microsoft-prod.deb \
+  && apt-get install -y --no-install-recommends libmsquic libxdp1 libnl-3-200 libnl-route-3-200 \
   && apt-get autoremove --purge -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*

--- a/dev.alpine.Dockerfile
+++ b/dev.alpine.Dockerfile
@@ -26,7 +26,7 @@ USER root
 # Upgrade internal tools and packages first
 RUN apk update \
   && apk upgrade \
-  && apk add --no-cache icu-data-full icu-libs iputils-ping krb5-libs tzdata zstd-dev \
+  && apk add --no-cache icu-data-full icu-libs iputils-ping krb5-libs libmsquic tzdata zstd-dev \
   && apk cache sync \
   && rm -rf /var/cache/apk/*
 

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -28,7 +28,7 @@ USER root
 
 # Upgrade internal tools and packages first
 RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/packages-microsoft-prod.deb \
-  && apt-get update \
+  apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends iputils-ping libgssapi-krb5-2 libzstd-dev \
   && apt-get install -y --no-install-recommends /packages-microsoft-prod.deb \

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -29,7 +29,6 @@ USER root
 # Upgrade internal tools and packages first
 RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/tmp/packages-microsoft-prod.deb \
   apt-get update \
-  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends ca-certificates gnupg \
   && dpkg -i /tmp/packages-microsoft-prod.deb \
   && apt-get update \

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -27,11 +27,14 @@ FROM mcr.microsoft.com/dotnet/runtime:10.0-resolute AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/packages-microsoft-prod.deb \
+RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/tmp/packages-microsoft-prod.deb \
   apt-get update \
   && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends ca-certificates gnupg \
+  && dpkg -i /tmp/packages-microsoft-prod.deb \
+  && apt-get update \
+  && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends iputils-ping libgssapi-krb5-2 libzstd-dev \
-  && apt-get install -y --no-install-recommends /packages-microsoft-prod.deb \
   && apt-get install -y --no-install-recommends libmsquic libxdp1 libnl-3-200 libnl-route-3-200 \
   && apt-get autoremove --purge -y \
   && apt-get clean -y \

--- a/release.Dockerfile
+++ b/release.Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:labs
 
-# BUILD IMAGE
+# --- BUILD IMAGE ---
 FROM mcr.microsoft.com/dotnet/sdk:10.0-resolute AS build
 USER root
 
@@ -20,14 +20,19 @@ RUN dotnet restore ./src/AzzyBot.Bot/AzzyBot.Bot.csproj --configfile ./Nuget.con
   && dotnet build ./src/AzzyBot.Bot/AzzyBot.Bot.csproj -c $CONFIG --no-incremental --no-restore --no-self-contained --ucr \
   && dotnet publish ./src/AzzyBot.Bot/AzzyBot.Bot.csproj -c $CONFIG --no-build --no-restore --no-self-contained -o out --ucr
 
-# RUNNER IMAGE
+ADD https://packages.microsoft.com/config/ubuntu/26.04/packages-microsoft-prod.deb /packages-microsoft-prod.deb
+
+# --- RUNNER IMAGE ---
 FROM mcr.microsoft.com/dotnet/runtime:10.0-resolute AS runner
 USER root
 
 # Upgrade internal tools and packages first
-RUN apt-get update \
+RUN --mount=type=bind,from=build,source=/packages-microsoft-prod.deb,target=/packages-microsoft-prod.deb \
+  && apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends iputils-ping libgssapi-krb5-2 libzstd-dev \
+  && apt-get install -y --no-install-recommends /packages-microsoft-prod.deb \
+  && apt-get install -y --no-install-recommends libmsquic libxdp1 libnl-3-200 libnl-route-3-200 \
   && apt-get autoremove --purge -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*

--- a/release.alpine.Dockerfile
+++ b/release.alpine.Dockerfile
@@ -26,7 +26,7 @@ USER root
 # Upgrade internal tools and packages first
 RUN apk update \
   && apk upgrade \
-  && apk add --no-cache icu-data-full icu-libs iputils-ping krb5-libs tzdata zstd-dev \
+  && apk add --no-cache icu-data-full icu-libs iputils-ping krb5-libs libmsquic tzdata zstd-dev \
   && apk cache sync \
   && rm -rf /var/cache/apk/*
 

--- a/src/AzzyBot.Bot/AzzyBot.Bot.csproj
+++ b/src/AzzyBot.Bot/AzzyBot.Bot.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup Condition="'$(Configuration)'=='Release' OR '$(Configuration)'=='Docker'">
     <Compile Remove="Commands\DebugCommands.cs" />
+    <Compile Remove="Utilities\Structs\AzzyDebugWebRequestStruct.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AzzyBot.Bot/Commands/DebugCommands.cs
+++ b/src/AzzyBot.Bot/Commands/DebugCommands.cs
@@ -204,18 +204,21 @@ public sealed class DebugCommands
 
             if (string.IsNullOrEmpty(req.Content))
             {
-                await context.EditResponseAsync(sb.ToString());
+                await context.DeleteResponseAsync();
+                await context.FollowupAsync(sb.ToString(), ephemeral: true);
                 return;
             }
 
             string fileName = $"WebRequestDebug_{DateTime.UtcNow:yyyy-MM-dd_HH-mm-ss-fffffff}.txt";
             string filePath = await FileOperations.CreateTempFileAsync(req.Content, fileName);
             await using FileStream fs = new(filePath, FileMode.Open, FileAccess.Read, FileShare.None);
-
             DiscordMessageBuilder builder = new();
-            builder.WithContent(sb.ToString());
             builder.AddFile(fileName, fs, AddFileOptions.CloseStream);
             await context.EditResponseAsync(builder);
+            if (File.Exists(filePath))
+                FileOperations.DeleteFile(filePath);
+
+            await context.FollowupAsync(sb.ToString(), ephemeral: true);
 
             return;
         }

--- a/src/AzzyBot.Bot/Commands/DebugCommands.cs
+++ b/src/AzzyBot.Bot/Commands/DebugCommands.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.IO;
+using System.Net.Quic;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -11,6 +13,8 @@ using AzzyBot.Bot.Commands.Choices;
 using AzzyBot.Bot.Logging;
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities.Helpers;
+using AzzyBot.Bot.Utilities.Structs;
+using AzzyBot.Core.Utilities;
 using AzzyBot.Core.Utilities.Encryption;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
@@ -179,9 +183,41 @@ public sealed class DebugCommands
 
             await context.DeferResponseAsync();
 
-            await _webRequestService.GetWebAsync(url, acceptJson: true);
+            AzzyDebugWebRequestStruct req = await _webRequestService.DebugGetWebAsync(url, acceptJson: true);
+            StringBuilder sb = new();
+            sb.AppendLine(CultureInfo.InvariantCulture, $"Request Uri: {req.RequestUri}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"Method: {req.Method}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"QUIC Support: {QuicConnection.IsSupported}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"Version: {req.HttpVersion}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"Status Code: {req.StatusCode}");
+            foreach (KeyValuePair<string, IEnumerable<string>> header in req.ReqHeaders)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"Request Header: {header.Key} - {string.Join(", ", header.Value)}");
+            }
 
-            await context.EditResponseAsync($"Web service test for *{url}* was successful!");
+            foreach (KeyValuePair<string, IEnumerable<string>> header in req.ResHeaders)
+            {
+                sb.AppendLine(CultureInfo.InvariantCulture, $"Response Header: {header.Key} - {string.Join(", ", header.Value)}");
+            }
+
+            sb.AppendLine(CultureInfo.InvariantCulture, $"Retries: {req.Retries}");
+
+            if (string.IsNullOrEmpty(req.Content))
+            {
+                await context.EditResponseAsync(sb.ToString());
+                return;
+            }
+
+            string fileName = $"WebRequestDebug_{DateTime.UtcNow:yyyy-MM-dd_HH-mm-ss-fffffff}.txt";
+            string filePath = await FileOperations.CreateTempFileAsync(req.Content, fileName);
+            await using FileStream fs = new(filePath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+            DiscordMessageBuilder builder = new();
+            builder.WithContent(sb.ToString());
+            builder.AddFile(fileName, fs, AddFileOptions.CloseStream);
+            await context.EditResponseAsync(builder);
+
+            return;
         }
     }
 }

--- a/src/AzzyBot.Bot/Commands/DebugCommands.cs
+++ b/src/AzzyBot.Bot/Commands/DebugCommands.cs
@@ -183,7 +183,7 @@ public sealed class DebugCommands
 
             await context.DeferResponseAsync();
 
-            AzzyDebugWebRequestStruct req = await _webRequestService.DebugGetWebAsync(url, acceptJson: true);
+            AzzyDebugWebRequestStruct req = await _webRequestService.DebugGetWebAsync(url);
             StringBuilder sb = new();
             sb.AppendLine(CultureInfo.InvariantCulture, $"Request Uri: {req.RequestUri}");
             sb.AppendLine(CultureInfo.InvariantCulture, $"Method: {req.Method}");

--- a/src/AzzyBot.Bot/Logging/LoggerActions.cs
+++ b/src/AzzyBot.Bot/Logging/LoggerActions.cs
@@ -73,6 +73,9 @@ public static partial class LoggerActions
     [LoggerMessage(LogLevel.Information, "Invite me using the following url: {invite}")]
     public static partial void InviteUrl(this ILogger<DiscordBotServiceHost> logger, string invite);
 
+    [LoggerMessage(LogLevel.Information, "Status of HTTP/3 QUIC Support: {quic}")]
+    public static partial void Http3QuicSupport(this ILogger<WebRequestService> logger, bool quic);
+
     [LoggerMessage(LogLevel.Information, "Command {command} requested by {user} to execute")]
     public static partial void CommandRequested(this ILogger logger, string command, string user);
 

--- a/src/AzzyBot.Bot/Program.cs
+++ b/src/AzzyBot.Bot/Program.cs
@@ -22,7 +22,11 @@ namespace AzzyBot.Bot;
 
 public static class Program
 {
+#if DEBUG || RELEASE
     public static async Task Main(string[] args)
+#else
+    public static async Task Main()
+#endif
     {
         #region Parse arguments
 

--- a/src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Utilities.Records;
+#if DEBUG || DOCKER_DEBUG
+using AzzyBot.Bot.Utilities.Structs;
+#endif
 
 namespace AzzyBot.Bot.Services.Interfaces;
 
@@ -14,6 +17,9 @@ public interface IWebRequestService
     Task<AzzyIpAddressRecord> GetIpAddressesAsync();
     Task<long> GetPingAsync(Uri uri);
     Task<string?> GetWebAsync(Uri url, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true, bool noLogging = false);
+#if DEBUG || DOCKER_DEBUG
+    Task<AzzyDebugWebRequestStruct> DebugGetWebAsync(Uri url, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true, bool noLogging = false);
+#endif
     Task PostWebAsync(Uri url, string? content = null, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);
     Task PutWebAsync(Uri url, string? content = null, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);
     Task<string?> UploadAsync(Uri url, string file, string fileName, string filePath, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);

--- a/src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs
@@ -18,7 +18,7 @@ public interface IWebRequestService
     Task<long> GetPingAsync(Uri uri);
     Task<string?> GetWebAsync(Uri url, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true, bool noLogging = false);
 #if DEBUG || DOCKER_DEBUG
-    Task<AzzyDebugWebRequestStruct> DebugGetWebAsync(Uri url, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true, bool noLogging = false);
+    Task<AzzyDebugWebRequestStruct> DebugGetWebAsync(Uri url);
 #endif
     Task PostWebAsync(Uri url, string? content = null, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);
     Task PutWebAsync(Uri url, string? content = null, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true);

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -214,7 +214,7 @@ public sealed class WebRequestService : IWebRequestService
 
             const int maxRetries = 7;
             int retryCount = 0;
-            while (status is HttpStatusCode.TooManyRequests && retryCount <= maxRetries)
+            while (status is HttpStatusCode.TooManyRequests && retryCount is < maxRetries)
             {
                 _logger.BotRatelimited(url, retryCount);
 
@@ -284,7 +284,7 @@ public sealed class WebRequestService : IWebRequestService
 
             const int maxRetries = 7;
             int retryCount = 0;
-            while (status is HttpStatusCode.TooManyRequests && retryCount <= maxRetries)
+            while (status is HttpStatusCode.TooManyRequests && retryCount is < maxRetries)
             {
                 _logger.BotRatelimited(url, retryCount);
 

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -3,8 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+#if DEBUG || DOCKER_DEBUG
+using System.Net.Http.Headers;
+#endif
 using System.Net.Mime;
 using System.Net.NetworkInformation;
+using System.Net.Quic;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -14,18 +18,29 @@ using AzzyBot.Bot.Resources;
 using AzzyBot.Bot.Services.Interfaces;
 using AzzyBot.Bot.Utilities;
 using AzzyBot.Bot.Utilities.Records;
+#if DEBUG || DOCKER_DEBUG
+using AzzyBot.Bot.Utilities.Structs;
+#endif
 using AzzyBot.Core.Utilities;
 
 using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Services;
 
-public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebRequestService> logger) : IWebRequestService
+public sealed class WebRequestService : IWebRequestService
 {
-    private readonly IHttpClientFactory _factory = factory;
-    private readonly ILogger<WebRequestService> _logger = logger;
+    private readonly IHttpClientFactory _factory;
+    private readonly ILogger<WebRequestService> _logger;
     private const string MediaTypeJson = MediaTypeNames.Application.Json;
     private static readonly string HttpClientName = SoftwareStats.GetAppName;
+
+    public WebRequestService(IHttpClientFactory factory, ILogger<WebRequestService> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+
+        _logger.Http3QuicSupport(QuicConnection.IsSupported);
+    }
 
     public async Task<IReadOnlyList<bool>> CheckForApiPermissionsAsync(IReadOnlyList<Uri> urls, IReadOnlyDictionary<string, string> headers)
     {
@@ -42,7 +57,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
             try
             {
                 using HttpRequestMessage request = new(HttpMethod.Get, url);
-                AddRequestHeaders(request, headers, acceptJson: true, noCache: true);
+                PrepareRequests(request, headers, acceptJson: true, noCache: true);
 
                 using HttpResponseMessage? response = await client.SendAsync(request);
                 success = response.IsSuccessStatusCode;
@@ -71,7 +86,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
         try
         {
             using HttpRequestMessage request = new(HttpMethod.Delete, uri);
-            AddRequestHeaders(request, headers, acceptJson: acceptJson, noCache: noCache);
+            PrepareRequests(request, headers, acceptJson: acceptJson, noCache: noCache);
 
             using HttpResponseMessage response = await client.SendAsync(request);
             if (response.IsSuccessStatusCode)
@@ -97,7 +112,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
         {
             using HttpClient client = _factory.CreateClient(HttpClientName);
             using HttpRequestMessage request = new(HttpMethod.Get, url);
-            AddRequestHeaders(request, headers, acceptJson: acceptJson, acceptImage: acceptImage, noCache: noCache);
+            PrepareRequests(request, headers, acceptJson: acceptJson, acceptImage: acceptImage, noCache: noCache);
 
             using HttpResponseMessage response = await client.SendAsync(request);
             response.EnsureSuccessStatusCode();
@@ -191,7 +206,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
             string? responseContent;
             using (HttpRequestMessage request = new(HttpMethod.Get, url))
             {
-                AddRequestHeaders(request, headers, acceptJson: acceptJson, noCache: noCache);
+                PrepareRequests(request, headers, acceptJson: acceptJson, noCache: noCache);
                 using HttpResponseMessage response = await client.SendAsync(request);
                 status = response.StatusCode;
                 responseContent = await response.Content.ReadAsStringAsync();
@@ -207,7 +222,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
                 retryCount++;
 
                 using HttpRequestMessage retryRequest = new(HttpMethod.Get, url);
-                AddRequestHeaders(retryRequest, headers, acceptJson: acceptJson, noCache: noCache);
+                PrepareRequests(retryRequest, headers, acceptJson: acceptJson, noCache: noCache);
 
                 using HttpResponseMessage response = await client.SendAsync(retryRequest);
                 status = response.StatusCode;
@@ -245,6 +260,82 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
         }
     }
 
+#if DEBUG || DOCKER_DEBUG
+    public async Task<AzzyDebugWebRequestStruct> DebugGetWebAsync(Uri url, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true, bool noLogging = false)
+    {
+        try
+        {
+            using HttpClient client = _factory.CreateClient(HttpClientName);
+            HttpStatusCode status;
+            Version httpVersion;
+            HttpRequestHeaders reqHeaders;
+            HttpResponseHeaders resHeaders;
+            string? responseContent;
+            using (HttpRequestMessage request = new(HttpMethod.Get, url))
+            {
+                PrepareRequests(request, headers, acceptJson: acceptJson, noCache: noCache);
+                using HttpResponseMessage response = await client.SendAsync(request);
+                httpVersion = response.Version;
+                status = response.StatusCode;
+                reqHeaders = request.Headers;
+                resHeaders = response.Headers;
+                responseContent = await response.Content.ReadAsStringAsync();
+            }
+
+            const int maxRetries = 7;
+            int retryCount = 0;
+            while (status is HttpStatusCode.TooManyRequests && retryCount <= maxRetries)
+            {
+                _logger.BotRatelimited(url, retryCount);
+
+                await Task.Delay(TimeSpan.FromSeconds(Math.Pow(2, retryCount)));
+                retryCount++;
+
+                using HttpRequestMessage retryRequest = new(HttpMethod.Get, url);
+                PrepareRequests(retryRequest, headers, acceptJson: acceptJson, noCache: noCache);
+
+                using HttpResponseMessage response = await client.SendAsync(retryRequest);
+                httpVersion = response.Version;
+                status = response.StatusCode;
+                reqHeaders = retryRequest.Headers;
+                resHeaders = response.Headers;
+                responseContent = await response.Content.ReadAsStringAsync();
+            }
+
+            return new()
+            {
+                RequestUri = url,
+                Method = HttpMethod.Get,
+                HttpVersion = httpVersion,
+                StatusCode = status,
+                ReqHeaders = reqHeaders,
+                ResHeaders = resHeaders,
+                Retries = retryCount,
+                Content = responseContent
+            };
+        }
+        catch (InvalidOperationException)
+        {
+            _logger.WebInvalidUri(url);
+            throw;
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            if (!noLogging)
+                _logger.WebRequestFailed(HttpMethod.Get, ex.Message, url);
+
+            throw;
+        }
+        catch (Exception ex)
+        {
+            if (!noLogging)
+                _logger.WebRequestFailed(HttpMethod.Get, ex.Message, url);
+
+            throw;
+        }
+    }
+#endif
+
     public async Task PostWebAsync(Uri url, string? content = null, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true)
     {
         try
@@ -256,7 +347,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
                 Content = httpContent
             };
 
-            AddRequestHeaders(request, headers, acceptJson: acceptJson, noCache: noCache);
+            PrepareRequests(request, headers, acceptJson: acceptJson, noCache: noCache);
 
             using HttpResponseMessage response = await client.SendAsync(request);
             if (response.IsSuccessStatusCode)
@@ -287,7 +378,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
                 Content = httpContent
             };
 
-            AddRequestHeaders(request, headers, acceptJson: acceptJson, noCache: noCache);
+            PrepareRequests(request, headers, acceptJson: acceptJson, noCache: noCache);
 
             using HttpResponseMessage response = await client.SendAsync(request);
             if (response.IsSuccessStatusCode)
@@ -322,7 +413,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
                 Content = httpContent
             };
 
-            AddRequestHeaders(request, headers, acceptJson: acceptJson, noCache: noCache);
+            PrepareRequests(request, headers, acceptJson: acceptJson, noCache: noCache);
 
             using HttpResponseMessage response = await client.SendAsync(request);
             if (response.IsSuccessStatusCode)
@@ -344,21 +435,23 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
         }
     }
 
-    private static void AddRequestHeaders(HttpRequestMessage message, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool acceptImage = false, bool noCache = true)
+    private static void PrepareRequests(HttpRequestMessage request, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool acceptImage = false, bool noCache = true)
     {
+        request.VersionPolicy = HttpVersionPolicy.RequestVersionOrHigher;
+
         if (acceptImage && acceptJson)
             throw new ArgumentException("Cannot accept both image and JSON content types.");
 
         if (acceptImage)
-            message.Headers.Accept.Add(new("image/*")); // Manual to allow all image types
+            request.Headers.Accept.Add(new("image/*")); // Manual to allow all image types
 
         if (acceptJson)
-            message.Headers.Accept.Add(new(MediaTypeJson));
+            request.Headers.Accept.Add(new(MediaTypeJson));
 
         if (noCache)
         {
-            message.Headers.CacheControl = new() { NoCache = true };
-            message.Headers.Pragma.Add(new("no-cache"));
+            request.Headers.CacheControl = new() { NoCache = true };
+            request.Headers.Pragma.Add(new("no-cache"));
         }
 
         if (headers is null)
@@ -366,7 +459,7 @@ public sealed class WebRequestService(IHttpClientFactory factory, ILogger<WebReq
 
         foreach (KeyValuePair<string, string> header in headers)
         {
-            message.Headers.Add(header.Key, header.Value);
+            request.Headers.Add(header.Key, header.Value);
         }
     }
 }

--- a/src/AzzyBot.Bot/Services/WebRequestService.cs
+++ b/src/AzzyBot.Bot/Services/WebRequestService.cs
@@ -261,7 +261,7 @@ public sealed class WebRequestService : IWebRequestService
     }
 
 #if DEBUG || DOCKER_DEBUG
-    public async Task<AzzyDebugWebRequestStruct> DebugGetWebAsync(Uri url, IReadOnlyDictionary<string, string>? headers = null, bool acceptJson = false, bool noCache = true, bool noLogging = false)
+    public async Task<AzzyDebugWebRequestStruct> DebugGetWebAsync(Uri url)
     {
         try
         {
@@ -273,7 +273,7 @@ public sealed class WebRequestService : IWebRequestService
             string? responseContent;
             using (HttpRequestMessage request = new(HttpMethod.Get, url))
             {
-                PrepareRequests(request, headers, acceptJson: acceptJson, noCache: noCache);
+                PrepareRequests(request, headers: null, acceptJson: true, noCache: true);
                 using HttpResponseMessage response = await client.SendAsync(request);
                 httpVersion = response.Version;
                 status = response.StatusCode;
@@ -292,7 +292,7 @@ public sealed class WebRequestService : IWebRequestService
                 retryCount++;
 
                 using HttpRequestMessage retryRequest = new(HttpMethod.Get, url);
-                PrepareRequests(retryRequest, headers, acceptJson: acceptJson, noCache: noCache);
+                PrepareRequests(retryRequest, headers: null, acceptJson: true, noCache: true);
 
                 using HttpResponseMessage response = await client.SendAsync(retryRequest);
                 httpVersion = response.Version;
@@ -321,16 +321,12 @@ public sealed class WebRequestService : IWebRequestService
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            if (!noLogging)
-                _logger.WebRequestFailed(HttpMethod.Get, ex.Message, url);
-
+            _logger.WebRequestFailed(HttpMethod.Get, ex.Message, url);
             throw;
         }
         catch (Exception ex)
         {
-            if (!noLogging)
-                _logger.WebRequestFailed(HttpMethod.Get, ex.Message, url);
-
+            _logger.WebRequestFailed(HttpMethod.Get, ex.Message, url);
             throw;
         }
     }

--- a/src/AzzyBot.Bot/Utilities/Structs/AzzyDebugWebRequestStruct.cs
+++ b/src/AzzyBot.Bot/Utilities/Structs/AzzyDebugWebRequestStruct.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+
+namespace AzzyBot.Bot.Utilities.Structs;
+
+public readonly struct AzzyDebugWebRequestStruct : IEquatable<AzzyDebugWebRequestStruct>
+{
+    public required Uri RequestUri { get; init; }
+    public required HttpMethod Method { get; init; }
+    public required Version HttpVersion { get; init; }
+    public required HttpStatusCode StatusCode { get; init; }
+    public required HttpRequestHeaders ReqHeaders { get; init; }
+    public required HttpResponseHeaders ResHeaders { get; init; }
+    public required int Retries { get; init; }
+    public string? Content { get; init; }
+
+    public override bool Equals(object? obj)
+        => obj is AzzyDebugWebRequestStruct other && Equals(other);
+
+    public bool Equals(AzzyDebugWebRequestStruct other)
+        => RequestUri == other.RequestUri &&
+            Method == other.Method &&
+            HttpVersion == other.HttpVersion &&
+            StatusCode == other.StatusCode &&
+            ReqHeaders == other.ReqHeaders &&
+            ResHeaders == other.ResHeaders &&
+            Retries == other.Retries &&
+            Content == other.Content;
+
+    public override int GetHashCode()
+        => HashCode.Combine(RequestUri, Method, HttpVersion, StatusCode, ReqHeaders, ResHeaders, Retries, Content);
+
+    public static bool operator ==(AzzyDebugWebRequestStruct? left, AzzyDebugWebRequestStruct? right)
+        => left?.Equals(right) is true;
+
+    public static bool operator !=(AzzyDebugWebRequestStruct? left, AzzyDebugWebRequestStruct? right)
+        => !left?.Equals(right) is true;
+}

--- a/src/AzzyBot.Core/Utilities/HardwareStats.cs
+++ b/src/AzzyBot.Core/Utilities/HardwareStats.cs
@@ -18,7 +18,7 @@ public static class HardwareStats
     #endregion Constants
 
     public static bool CheckIfLinuxOs
-        => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        => OperatingSystem.IsLinux();
 
     public static async Task<Dictionary<int, double>> GetSystemCpuAsync()
     {


### PR DESCRIPTION
This pull request introduces several improvements to the bot's HTTP/3 and QUIC support, enhances debugging capabilities for web requests, and updates Dockerfile dependencies to ensure all necessary libraries are present for QUIC. The most significant changes are the addition of a debug web request method, improved logging of QUIC support, and Dockerfile updates for runtime library compatibility.

**QUIC/HTTP3 Support and Debugging Enhancements:**

* Added a new debug web request method `DebugGetWebAsync` to `IWebRequestService` and its implementation, which returns detailed request/response info for debugging, including HTTP version, headers, status, and retry count. This is only available in debug or Docker debug builds. (`src/AzzyBot.Bot/Services/Interfaces/IWebRequestService.cs` [[1]](diffhunk://#diff-8d4f906f795cdf4db2c7a5d7f0ae8c51debe73a5434c89dcf43b4260378dbf5dR20-R22) `src/AzzyBot.Bot/Services/WebRequestService.cs` [[2]](diffhunk://#diff-b479149af84e8d48c01502ca94c79cc97091a311316e0467d9160972342e9ce0R263-R338) `src/AzzyBot.Bot/Commands/DebugCommands.cs` [[3]](diffhunk://#diff-17e8d7a9824a62eb7efafe60e5f9b024d04433cc12d05f3edc3a4258ba837f87L182-R220)
* Improved logging to record the status of HTTP/3 QUIC support at service startup. (`src/AzzyBot.Bot/Logging/LoggerActions.cs` [[1]](diffhunk://#diff-b3b250ae9a218abd052f350978899e531bc097293596fc6adb2d545535e2cd9aR76-R78) `src/AzzyBot.Bot/Services/WebRequestService.cs` [[2]](diffhunk://#diff-b479149af84e8d48c01502ca94c79cc97091a311316e0467d9160972342e9ce0R21-R44)
* Updated the debug command to use the new debug web request method and output detailed information, including QUIC support and HTTP version, with optional file attachment for response content. (`src/AzzyBot.Bot/Commands/DebugCommands.cs` [src/AzzyBot.Bot/Commands/DebugCommands.csL182-R220](diffhunk://#diff-17e8d7a9824a62eb7efafe60e5f9b024d04433cc12d05f3edc3a4258ba837f87L182-R220))

**Dockerfile and Dependency Updates:**

* Updated both Ubuntu and Alpine Dockerfiles to install `libmsquic` and related networking libraries required for HTTP/3/QUIC support, and improved package installation for runner images. (`dev.Dockerfile` [[1]](diffhunk://#diff-3ed65642ec1610de6b0f162c77dc8499662ebeb7057d3f6c89108952d1cb33deL23-R38) `release.Dockerfile` [[2]](diffhunk://#diff-f1bd05d0cabc71ca98e58fb9f5bb9f51d115733d359f9d289ebc0d158b0cb2a8L23-R38) `dev.alpine.Dockerfile` [[3]](diffhunk://#diff-434b08383a91d5e4883675176bbff7b4809a83f519bab6207710728a2c750ca8L29-R29) `release.alpine.Dockerfile` [[4]](diffhunk://#diff-58401038a90aa7cb4db244527416d6665ad0807fb5baf2751514aceeb7313c6fL29-R29)
* Added the Microsoft package feed for Ubuntu 26.04 in Dockerfiles to ensure all required .NET and QUIC libraries are available. (`dev.Dockerfile` [[1]](diffhunk://#diff-3ed65642ec1610de6b0f162c77dc8499662ebeb7057d3f6c89108952d1cb33deL23-R38) `release.Dockerfile` [[2]](diffhunk://#diff-f1bd05d0cabc71ca98e58fb9f5bb9f51d115733d359f9d289ebc0d158b0cb2a8L23-R38)

**General Code Maintenance:**

* Refactored request header handling by renaming `AddRequestHeaders` to `PrepareRequests` for clarity and consistency. (`src/AzzyBot.Bot/Services/WebRequestService.cs` [[1]](diffhunk://#diff-b479149af84e8d48c01502ca94c79cc97091a311316e0467d9160972342e9ce0L45-R60) [[2]](diffhunk://#diff-b479149af84e8d48c01502ca94c79cc97091a311316e0467d9160972342e9ce0L74-R89) [[3]](diffhunk://#diff-b479149af84e8d48c01502ca94c79cc97091a311316e0467d9160972342e9ce0L100-R115) [[4]](diffhunk://#diff-b479149af84e8d48c01502ca94c79cc97091a311316e0467d9160972342e9ce0L194-R209) [[5]](diffhunk://#diff-b479149af84e8d48c01502ca94c79cc97091a311316e0467d9160972342e9ce0L210-R225) [[6]](diffhunk://#diff-b479149af84e8d48c01502ca94c79cc97091a311316e0467d9160972342e9ce0L259-R350)
* Excluded `AzzyDebugWebRequestStruct.cs` from release and Docker builds to avoid unnecessary debug code in production. (`src/AzzyBot.Bot/AzzyBot.Bot.csproj` [src/AzzyBot.Bot/AzzyBot.Bot.csprojR31](diffhunk://#diff-10ab2decabf0031a83a2737daa6e5be237b383bf70c3a327815e2385cd43792eR31))