### PR TITLE
Enhance CronJobManager and improve related jobs

### DIFF
--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastMountAutocomplete.cs
@@ -23,11 +23,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, IAzuraCastApiService azuraCast, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
+public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplete> logger, IAzuraCastApiService azuraCast, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IWebRequestService webRequest) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastMountAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCast;
-    private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
+    private readonly ICronJobManager _cronJobManager = cronJobManager;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
     private readonly IWebRequestService _webRequest = webRequest;
@@ -67,7 +67,7 @@ public sealed class AzuraCastMountAutocomplete(ILogger<AzuraCastMountAutocomplet
         }
         catch (Exception e) when (e is HttpRequestException or InvalidOperationException)
         {
-            await _azuraCastPing.PingInstanceAsync(station.AzuraCast);
+            _cronJobManager.RunAzuraStatusPingJob(station.AzuraCast);
             return [];
         }
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
@@ -22,11 +22,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutocomplete> logger, IAzuraCastApiService azuraCastApi, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastPlaylistAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
-    private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
+    private readonly ICronJobManager _cronJobManager = cronJobManager;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 
@@ -70,7 +70,7 @@ public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutoc
         }
         catch (HttpRequestException)
         {
-            await _azuraCastPing.PingInstanceAsync(station.AzuraCast);
+            _cronJobManager.RunAzuraStatusPingJob(station.AzuraCast);
             return [];
         }
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsInDbAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsInDbAutocomplete.cs
@@ -21,11 +21,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastStationsInDbAutocomplete(ILogger<AzuraCastStationsInDbAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastStationsInDbAutocomplete(ILogger<AzuraCastStationsInDbAutocomplete> logger, IAzuraCastApiService azuraCastApi, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastStationsInDbAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCast = azuraCastApi;
-    private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
+    private readonly ICronJobManager _cronJobManager = cronJobManager;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 
@@ -72,7 +72,7 @@ public sealed class AzuraCastStationsInDbAutocomplete(ILogger<AzuraCastStationsI
             }
             catch (HttpRequestException)
             {
-                await _azuraCastPing.PingInstanceAsync(azuraCast);
+                _cronJobManager.RunAzuraStatusPingJob(azuraCast);
                 return results;
             }
 

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
@@ -19,11 +19,11 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, IAzuraCastApiService azuraCastApi, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
     private readonly ILogger<AzuraCastSystemLogAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-    private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
+    private readonly ICronJobManager _cronJobManager = cronJobManager;
     private readonly IDbActions _dbActions = dbActions;
     private readonly IDiscordBotService _botService = botService;
 
@@ -58,7 +58,7 @@ public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAut
         }
         catch (HttpRequestException)
         {
-            await _azuraCastPing.PingInstanceAsync(azuraCast);
+            _cronJobManager.RunAzuraStatusPingJob(azuraCast);
             return [];
         }
 

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -45,13 +45,14 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
         private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
+        private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
         private readonly IMusicStreamingService _musicStreaming = musicStreaming;
@@ -167,9 +168,9 @@ public sealed class AzuraCastCommands
                 return;
             }
 
-            if (!station.HasValue)
+            if (station is null)
             {
-                await _azuraCastApi.CheckForApiPermissionsAsync(dAzuraCast);
+                _cronJobManager.RunAzuraCheckApiPermissionsJob(dAzuraCast);
             }
             else
             {
@@ -181,7 +182,7 @@ public sealed class AzuraCastCommands
                     return;
                 }
 
-                await _azuraCastApi.CheckForApiPermissionsAsync(dStation);
+                _cronJobManager.RunAzuraCheckApiPermissionsJob(dStation);
             }
 
             await context.EditResponseAsync("I initiated the permission check.\nThere won't be another message if your permissions are set correctly.");

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -45,11 +45,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-        private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
@@ -264,8 +263,8 @@ public sealed class AzuraCastCommands
                 return;
             }
 
+            _cronJobManager.RunAzuraCheckUpdatesJob(dAzuraCast);
             await context.EditResponseAsync("I initiated the check for AzuraCast Updates.\nThere won't be another message if there are no updates available.");
-            await _azuraCastUpdate.CheckForAzuraCastUpdatesAsync(dAzuraCast, true);
         }
 
         [Command("get-system-logs"), Description("Get the system logs of the AzuraCast instance."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.InstanceAdminGroup]), AzuraCastOnlineCheck]

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -45,11 +45,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-        private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly ICronJobManager _cronJobManager = cronJobManager;
@@ -208,12 +207,9 @@ public sealed class AzuraCastCommands
                 return;
             }
 
-            if (!station.HasValue)
+            if (station is null)
             {
-                foreach (AzuraCastStationEntity dStation in dAzuraCast.Stations)
-                {
-                    await _azuraCastFile.CheckForFileChangesAsync(dStation);
-                }
+                _cronJobManager.RunAzuraCheckFileChangesJob(dAzuraCast);
             }
             else
             {
@@ -225,10 +221,12 @@ public sealed class AzuraCastCommands
                     return;
                 }
 
-                await _azuraCastFile.CheckForFileChangesAsync(dStation);
+                _cronJobManager.RunAzuraCheckFileChangesJob(dStation);
             }
 
-            await context.EditResponseAsync((!station.HasValue) ? "I initiated the cache refresh for all stations." : "I initiated the cache refresh for the selected station.");
+            await context.EditResponseAsync((station is not null)
+                ? "I initiated the cache refresh for all stations."
+                : "I initiated the cache refresh for the selected station.");
         }
 
         [Command("force-online-check"), Description("Force the bot to check if the AzuraCast instance is online."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.InstanceAdminGroup])]

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -223,8 +223,8 @@ public sealed class AzuraCastCommands
             }
 
             await context.EditResponseAsync((station is not null)
-                ? "I initiated the cache refresh for all stations."
-                : "I initiated the cache refresh for the selected station.");
+                ? "I initiated the cache refresh for the selected station."
+                : "I initiated the cache refresh for all stations.");
         }
 
         [Command("force-online-check"), Description("Force the bot to check if the AzuraCast instance is online."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.InstanceAdminGroup])]

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -45,11 +45,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class AzuraCastCommands
 {
     [Command("azuracast"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms, AzzyModules.AzuraCast])]
-    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
+    public sealed class AzuraCastGroup(ILogger<AzuraCastGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService, IMusicStreamingService musicStreaming)
     {
         private readonly ILogger<AzuraCastGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-        private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
@@ -245,8 +244,8 @@ public sealed class AzuraCastCommands
                 return;
             }
 
+            _cronJobManager.RunAzuraStatusPingJob(dAzuraCast);
             await context.EditResponseAsync("I initiated the online check for the AzuraCast instance.");
-            await _azuraCastPing.PingInstanceAsync(dAzuraCast);
         }
 
         [Command("force-update-check"), Description("Force the bot to search for AzuraCast Updates."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.InstanceAdminGroup]), AzuraCastOnlineCheck]

--- a/src/AzzyBot.Bot/Commands/Checks/AzuraCastOnlineCheck.cs
+++ b/src/AzzyBot.Bot/Commands/Checks/AzuraCastOnlineCheck.cs
@@ -16,6 +16,7 @@ namespace AzzyBot.Bot.Commands.Checks;
 
 public sealed class AzuraCastOnlineCheck(ILogger<AzuraCastOnlineCheck> logger, IDbActions dbActions) : IContextCheck<AzuraCastOnlineCheckAttribute>
 {
+    private readonly ILogger<AzuraCastOnlineCheck> _logger = logger;
     private readonly IDbActions _dbActions = dbActions;
 
     public async ValueTask<string?> ExecuteCheckAsync(AzuraCastOnlineCheckAttribute attribute, CommandContext context)
@@ -29,7 +30,7 @@ public sealed class AzuraCastOnlineCheck(ILogger<AzuraCastOnlineCheck> logger, I
         AzuraCastEntity? azuraCast = await _dbActions.ReadAzuraCastAsync(context.Guild.Id);
         if (azuraCast is null)
         {
-            logger.DatabaseAzuraCastNotFound(context.Guild.Id);
+            _logger.DatabaseAzuraCastNotFound(context.Guild.Id);
             return "AzuraCast is null!";
         }
 

--- a/src/AzzyBot.Bot/Commands/Choices/MusicStreamingPlatformProvider.cs
+++ b/src/AzzyBot.Bot/Commands/Choices/MusicStreamingPlatformProvider.cs
@@ -17,5 +17,5 @@ public sealed class MusicStreamingPlatformProvider : IChoiceProvider
     ];
 
     public ValueTask<IEnumerable<DiscordApplicationCommandOptionChoice>> ProvideAsync(CommandParameter parameter)
-    => ValueTask.FromResult(Platforms);
+        => ValueTask.FromResult(Platforms);
 }

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -154,7 +154,7 @@ public sealed class ConfigCommands
                 return;
             }
 
-            await _botService.CheckPermissionsAsync(context.Guild, [notificationChannel.Id, outagesChannel.Id]);
+            _cronJobManager.RunAzzyBotCheckPermissionsJob(context.Guild, [notificationChannel.Id, outagesChannel.Id]);
             if (dAzuraCast.Checks.ServerStatus)
                 _cronJobManager.RunAzuraStatusPingJob(dAzuraCast);
         }
@@ -318,7 +318,7 @@ public sealed class ConfigCommands
                     channels[0] = outagesChannel.Id;
                 }
 
-                await _botService.CheckPermissionsAsync(context.Guild, [.. channels]);
+                _cronJobManager.RunAzzyBotCheckPermissionsJob(context.Guild, [.. channels]);
             }
 
             if (url is not null)
@@ -456,7 +456,7 @@ public sealed class ConfigCommands
                     channels.Add(uploadChannel.Id);
 
                 if (channels.Count is not 0)
-                    await _botService.CheckPermissionsAsync(context.Guild, [.. channels]);
+                    _cronJobManager.RunAzzyBotCheckPermissionsJob(context.Guild, [.. channels]);
             }
 
             if (stationId.HasValue || !string.IsNullOrWhiteSpace(apiKey))
@@ -566,7 +566,7 @@ public sealed class ConfigCommands
             await context.EditResponseAsync(GeneralStrings.CoreSettingsModified);
 
             if (adminChannel is not null)
-                await _botService.CheckPermissionsAsync(context.Guild, [adminChannel.Id]);
+                _cronJobManager.RunAzzyBotCheckPermissionsJob(context.Guild, [adminChannel.Id]);
         }
 
         [Command("get-settings"), Description("Get all configured settings in a direct message.")]

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -42,11 +42,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-        private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
@@ -158,7 +157,7 @@ public sealed class ConfigCommands
 
             await _botService.CheckPermissionsAsync(context.Guild, [notificationChannel.Id, outagesChannel.Id]);
             if (dAzuraCast.Checks.ServerStatus)
-                await _azuraCastPing.PingInstanceAsync(dAzuraCast);
+                _cronJobManager.RunAzuraStatusPingJob(dAzuraCast);
         }
 
         [Command("add-azuracast-station"), Description("Add an AzuraCast station to your instance."), ModuleActivatedCheck([AzzyModules.AzuraCast]), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.InstanceAdminGroup])]
@@ -333,7 +332,7 @@ public sealed class ConfigCommands
                 }
 
                 if (dAzuraCast.Checks.ServerStatus)
-                    await _azuraCastPing.PingInstanceAsync(dAzuraCast);
+                    _cronJobManager.RunAzuraStatusPingJob(dAzuraCast);
             }
         }
 
@@ -403,7 +402,7 @@ public sealed class ConfigCommands
                 }
 
                 if (serverStatus is 1)
-                    await _azuraCastPing.PingInstanceAsync(dAzuraCast);
+                    _cronJobManager.RunAzuraStatusPingJob(dAzuraCast);
 
                 if (updates is 1)
                     await _azuraCastUpdate.CheckForAzuraCastUpdatesAsync(dAzuraCast);
@@ -639,7 +638,7 @@ public sealed class ConfigCommands
                         }
                         catch (HttpRequestException)
                         {
-                            await _azuraCastPing.PingInstanceAsync(ac);
+                            _cronJobManager.RunAzuraStatusPingJob(ac);
                             break;
                         }
                         catch (InvalidOperationException)

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -42,11 +42,10 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-        private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
         private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
@@ -405,7 +404,7 @@ public sealed class ConfigCommands
                     _cronJobManager.RunAzuraStatusPingJob(dAzuraCast);
 
                 if (updates is 1)
-                    await _azuraCastUpdate.CheckForAzuraCastUpdatesAsync(dAzuraCast);
+                    _cronJobManager.RunAzuraCheckUpdatesJob(dAzuraCast);
             }
         }
 

--- a/src/AzzyBot.Bot/Commands/ConfigCommands.cs
+++ b/src/AzzyBot.Bot/Commands/ConfigCommands.cs
@@ -42,13 +42,13 @@ namespace AzzyBot.Bot.Commands;
 public sealed class ConfigCommands
 {
     [Command("config"), RequireGuild, RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator]), ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastFileService azuraCastFile, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class ConfigGroup(ILogger<ConfigGroup> logger, IAzuraCastApiService azuraCastApi, IAzuraCastPingService azuraCastPing, IAzuraCastUpdateService azuraCastUpdate, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService)
     {
         private readonly ILogger<ConfigGroup> _logger = logger;
         private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
-        private readonly IAzuraCastFileService _azuraCastFile = azuraCastFile;
         private readonly IAzuraCastPingService _azuraCastPing = azuraCastPing;
         private readonly IAzuraCastUpdateService _azuraCastUpdate = azuraCastUpdate;
+        private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
         private readonly IDiscordBotService _botService = botService;
 
@@ -217,7 +217,7 @@ public sealed class ConfigCommands
             }
 
             if (dAzuraCast.IsOnline)
-                await _azuraCastFile.CheckForFileChangesAsync(dStation);
+                _cronJobManager.RunAzuraCheckFileChangesJob(dStation);
         }
 
         [Command("delete-azuracast"), Description("Delete the existing AzuraCast setup."), ModuleActivatedCheck([AzzyModules.AzuraCast]), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.InstanceAdminGroup])]
@@ -482,7 +482,7 @@ public sealed class ConfigCommands
                 }
 
                 if (dAzuraCast.IsOnline)
-                    await _azuraCastFile.CheckForFileChangesAsync(dStation);
+                    _cronJobManager.RunAzuraCheckFileChangesJob(dStation);
             }
 
             await context.DeleteResponseAsync();
@@ -540,7 +540,7 @@ public sealed class ConfigCommands
                 }
 
                 if (dAzuraCast.IsOnline)
-                    await _azuraCastFile.CheckForFileChangesAsync(dStation);
+                    _cronJobManager.RunAzuraCheckFileChangesJob(dStation);
             }
         }
 

--- a/src/AzzyBot.Bot/Commands/CoreCommands.cs
+++ b/src/AzzyBot.Bot/Commands/CoreCommands.cs
@@ -32,12 +32,12 @@ namespace AzzyBot.Bot.Commands;
 public sealed class CoreCommands
 {
     [Command("core"), RequireGuild, ModuleActivatedCheck([AzzyModules.LegalTerms])]
-    public sealed class CoreGroup(ILogger<CoreGroup> logger, IOptions<AzzyBotSettings> settings, IDbActions dbActions, IDiscordBotService botService)
+    public sealed class CoreGroup(ILogger<CoreGroup> logger, IOptions<AzzyBotSettings> settings, ICronJobManager cronJobManager, IDbActions dbActions)
     {
         private readonly ILogger<CoreGroup> _logger = logger;
         private readonly AzzyBotSettings _settings = settings.Value;
+        private readonly ICronJobManager _cronJobManager = cronJobManager;
         private readonly IDbActions _dbActions = dbActions;
-        private readonly IDiscordBotService _botService = botService;
 
         [Command("force-channel-permissions-check"), Description("Forces a check of the permissions for the bot in the necessary channel."), RequirePermissions(botPermissions: [], userPermissions: [DiscordPermission.Administrator])]
         public async ValueTask ForceChannelPermissionsCheckAsync(SlashCommandContext context)
@@ -53,9 +53,8 @@ public sealed class CoreCommands
                 return;
             }
 
+            _cronJobManager.RunAzzyBotCheckPermissionsJob(guild);
             await context.EditResponseAsync("I initiated a check of the permissions for the bot, please wait a little for the result.");
-
-            await _botService.CheckPermissionsAsync(guild);
         }
 
         [Command("help"), Description("Gives you an overview about all the available commands.")]

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using AzzyBot.Bot.Models.AzuraCast;
 using AzzyBot.Bot.Services.CronJobs;
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Data.Entities;
 
 using NCronJob;
 
@@ -15,8 +16,11 @@ public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotS
     private readonly IInstantJobRegistry _jobRegistry = jobRegistry;
     private readonly IDiscordBotService _botService = botService;
 
-    public void RunAzuraCheckApiPermissionsJob()
-        => _jobRegistry.RunInstantJob<AzuraCheckApiPermissionsJob>();
+    public void RunAzuraCheckApiPermissionsJob(AzuraCastEntity azuraCast)
+        => _jobRegistry.RunInstantJob<AzuraCheckApiPermissionsJob>(azuraCast);
+
+    public void RunAzuraCheckApiPermissionsJob(AzuraCastStationEntity station)
+        => _jobRegistry.RunInstantJob<AzuraCheckApiPermissionsJob>(station);
 
     public void RunAzuraCheckFileChangesJob()
         => _jobRegistry.RunInstantJob<AzuraCheckFileChangesJob>();

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -37,8 +37,8 @@ public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotS
     public void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem)
         => _jobRegistry.RunInstantJob<AzuraRequestJob>(queueItem);
 
-    public void RunAzuraStatusPingJob()
-        => _jobRegistry.RunInstantJob<AzuraStatusPingJob>();
+    public void RunAzuraStatusPingJob(AzuraCastEntity azuraCast)
+        => _jobRegistry.RunInstantJob<AzuraStatusPingJob>(azuraCast);
 
     public void RunAzzyBotCheckPermissionsJob()
         => _jobRegistry.RunInstantJob<AzzyBotCheckPermissionsJob>();

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -34,9 +34,6 @@ public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotS
     public void RunAzuraCheckUpdatesJob(AzuraCastEntity azuraCast)
         => _jobRegistry.RunInstantJob<AzuraCheckUpdatesJob>(azuraCast);
 
-    public void RunAzuraPersistentNowPlayingJob()
-        => _jobRegistry.RunInstantJob<AzuraPersistentNowPlayingJob>();
-
     public void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem)
         => _jobRegistry.RunInstantJob<AzuraRequestJob>(queueItem);
 
@@ -58,18 +55,6 @@ public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotS
 
     public void RunAzzyBotInactiveGuildJob()
         => _jobRegistry.RunInstantJob<AzzyBotInactiveGuildJob>();
-
-    public void RunAzzyBotUpdateCheckJob()
-        => _jobRegistry.RunInstantJob<AzzyBotUpdateCheckJob>();
-
-    public void RunDatabaseCleaningJob()
-        => _jobRegistry.RunInstantJob<DatabaseCleaningJob>();
-
-    public void RunLogfileCleaningJob()
-        => _jobRegistry.RunInstantJob<LogfileCleaningJob>();
-
-    public void RunMusicStreamingPersistentNowPlayingJob()
-        => _jobRegistry.RunInstantJob<MusicStreamingPersistentNowPlayingJob>();
 
     public async Task<bool> TryHandleAsync(IJobExecutionContext jobExecutionContext, Exception exception, CancellationToken cancellationToken)
     {

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -5,7 +5,10 @@ using System.Threading.Tasks;
 using AzzyBot.Bot.Models.AzuraCast;
 using AzzyBot.Bot.Services.CronJobs;
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Bot.Structs;
 using AzzyBot.Data.Entities;
+
+using DSharpPlus.Entities;
 
 using NCronJob;
 
@@ -40,8 +43,18 @@ public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotS
     public void RunAzuraStatusPingJob(AzuraCastEntity azuraCast)
         => _jobRegistry.RunInstantJob<AzuraStatusPingJob>(azuraCast);
 
-    public void RunAzzyBotCheckPermissionsJob()
-        => _jobRegistry.RunInstantJob<AzzyBotCheckPermissionsJob>();
+    public void RunAzzyBotCheckPermissionsJob(DiscordGuild guild, ulong[] guildIds)
+        => _jobRegistry.RunInstantJob<AzzyBotCheckPermissionsJob>(new AzzyCheckPermissionsStruct()
+        {
+            DiscordGuild = guild,
+            DiscordGuildIds = [.. guildIds]
+        });
+
+    public void RunAzzyBotCheckPermissionsJob(GuildEntity guild)
+        => _jobRegistry.RunInstantJob<AzzyBotCheckPermissionsJob>(new AzzyCheckPermissionsStruct()
+        {
+            GuildEntity = guild
+        });
 
     public void RunAzzyBotInactiveGuildJob()
         => _jobRegistry.RunInstantJob<AzzyBotInactiveGuildJob>();

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -22,8 +22,11 @@ public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotS
     public void RunAzuraCheckApiPermissionsJob(AzuraCastStationEntity station)
         => _jobRegistry.RunInstantJob<AzuraCheckApiPermissionsJob>(station);
 
-    public void RunAzuraCheckFileChangesJob()
-        => _jobRegistry.RunInstantJob<AzuraCheckFileChangesJob>();
+    public void RunAzuraCheckFileChangesJob(AzuraCastEntity azuraCast)
+        => _jobRegistry.RunInstantJob<AzuraCheckFileChangesJob>(azuraCast);
+
+    public void RunAzuraCheckFileChangesJob(AzuraCastStationEntity station)
+        => _jobRegistry.RunInstantJob<AzuraCheckFileChangesJob>(station);
 
     public void RunAzuraCheckUpdatesJob()
         => _jobRegistry.RunInstantJob<AzuraCheckUpdatesJob>();

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -28,8 +28,8 @@ public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotS
     public void RunAzuraCheckFileChangesJob(AzuraCastStationEntity station)
         => _jobRegistry.RunInstantJob<AzuraCheckFileChangesJob>(station);
 
-    public void RunAzuraCheckUpdatesJob()
-        => _jobRegistry.RunInstantJob<AzuraCheckUpdatesJob>();
+    public void RunAzuraCheckUpdatesJob(AzuraCastEntity azuraCast)
+        => _jobRegistry.RunInstantJob<AzuraCheckUpdatesJob>(azuraCast);
 
     public void RunAzuraPersistentNowPlayingJob()
         => _jobRegistry.RunInstantJob<AzuraPersistentNowPlayingJob>();

--- a/src/AzzyBot.Bot/Services/CronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/CronJobManager.cs
@@ -15,11 +15,41 @@ public sealed class CronJobManager(IInstantJobRegistry jobRegistry, IDiscordBotS
     private readonly IInstantJobRegistry _jobRegistry = jobRegistry;
     private readonly IDiscordBotService _botService = botService;
 
-    public void RunAzzyBotInactiveGuildJob()
-        => _jobRegistry.RunInstantJob<AzzyBotInactiveGuildJob>();
+    public void RunAzuraCheckApiPermissionsJob()
+        => _jobRegistry.RunInstantJob<AzuraCheckApiPermissionsJob>();
+
+    public void RunAzuraCheckFileChangesJob()
+        => _jobRegistry.RunInstantJob<AzuraCheckFileChangesJob>();
+
+    public void RunAzuraCheckUpdatesJob()
+        => _jobRegistry.RunInstantJob<AzuraCheckUpdatesJob>();
+
+    public void RunAzuraPersistentNowPlayingJob()
+        => _jobRegistry.RunInstantJob<AzuraPersistentNowPlayingJob>();
 
     public void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem)
         => _jobRegistry.RunInstantJob<AzuraRequestJob>(queueItem);
+
+    public void RunAzuraStatusPingJob()
+        => _jobRegistry.RunInstantJob<AzuraStatusPingJob>();
+
+    public void RunAzzyBotCheckPermissionsJob()
+        => _jobRegistry.RunInstantJob<AzzyBotCheckPermissionsJob>();
+
+    public void RunAzzyBotInactiveGuildJob()
+        => _jobRegistry.RunInstantJob<AzzyBotInactiveGuildJob>();
+
+    public void RunAzzyBotUpdateCheckJob()
+        => _jobRegistry.RunInstantJob<AzzyBotUpdateCheckJob>();
+
+    public void RunDatabaseCleaningJob()
+        => _jobRegistry.RunInstantJob<DatabaseCleaningJob>();
+
+    public void RunLogfileCleaningJob()
+        => _jobRegistry.RunInstantJob<LogfileCleaningJob>();
+
+    public void RunMusicStreamingPersistentNowPlayingJob()
+        => _jobRegistry.RunInstantJob<MusicStreamingPersistentNowPlayingJob>();
 
     public async Task<bool> TryHandleAsync(IJobExecutionContext jobExecutionContext, Exception exception, CancellationToken cancellationToken)
     {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckApiPermissionsJob.cs
@@ -21,18 +21,29 @@ public sealed class AzuraCheckApiPermissionsJob(IAzuraCastApiService apiService,
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         try
         {
+            switch (context.Parameter)
+            {
+                case AzuraCastEntity azura when azura.IsOnline:
+                    await _apiService.CheckForApiPermissionsAsync(azura);
+                    return;
+
+                case AzuraCastStationEntity station when station.AzuraCast.IsOnline:
+                    await _apiService.CheckForApiPermissionsAsync(station);
+                    return;
+            }
+
             // Preferences needed to send messages to the guilds channel
             // Stations needed to check the api permissions
             IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadPrefs: true, loadStations: true);
-            if (!azuraCasts.Any())
+            if (azuraCasts.Count is 0)
                 return;
 
-            foreach (AzuraCastEntity azuraCast in azuraCasts.Where(a => a.IsOnline))
-            {
-                await _apiService.CheckForApiPermissionsAsync(azuraCast);
-            }
+            IEnumerable<AzuraCastEntity> azuraCastsToCheck = azuraCasts.Where(static a => a.IsOnline);
+            await Task.WhenAll(azuraCastsToCheck.Select(_apiService.CheckForApiPermissionsAsync));
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
@@ -21,19 +21,23 @@ public sealed class AzuraCheckFileChangesJob(IAzuraCastFileService azuraFileServ
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         try
         {
-            IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadPrefs: true, loadStations: true, loadStationChecks: true, loadGuild: true);
-            if (!azuraCasts.Any())
-                return;
-
-            foreach (AzuraCastEntity azuraCast in azuraCasts)
+            if (context.Parameter is not AzuraCastStationEntity azuraStation)
             {
-                foreach (AzuraCastStationEntity station in azuraCast.Stations.Where(s => s.Checks.FileChanges))
-                {
-                    await _azuraFileService.CheckForFileChangesAsync(station);
-                }
+                IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadPrefs: true, loadStations: true, loadStationChecks: true, loadGuild: true);
+                if (azuraCasts.Count is 0)
+                    return;
+
+                IEnumerable<AzuraCastStationEntity> stationsToCheck = azuraCasts.SelectMany(static ac => ac.Stations.Where(static s => s.Checks.FileChanges));
+                await Task.WhenAll(stationsToCheck.Select(_azuraFileService.CheckForFileChangesAsync));
+
+                return;
             }
+
+            await _azuraFileService.CheckForFileChangesAsync(azuraStation);
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckFileChangesJob.cs
@@ -25,19 +25,26 @@ public sealed class AzuraCheckFileChangesJob(IAzuraCastFileService azuraFileServ
 
         try
         {
-            if (context.Parameter is not AzuraCastStationEntity azuraStation)
+            IEnumerable<AzuraCastStationEntity> stationsToCheck;
+
+            switch (context.Parameter)
             {
-                IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadPrefs: true, loadStations: true, loadStationChecks: true, loadGuild: true);
-                if (azuraCasts.Count is 0)
+                case AzuraCastEntity azuraCast:
+                    stationsToCheck = azuraCast.Stations.Where(static s => s.Checks.FileChanges);
+                    await Task.WhenAll(stationsToCheck.Select(_azuraFileService.CheckForFileChangesAsync));
                     return;
 
-                IEnumerable<AzuraCastStationEntity> stationsToCheck = azuraCasts.SelectMany(static ac => ac.Stations.Where(static s => s.Checks.FileChanges));
-                await Task.WhenAll(stationsToCheck.Select(_azuraFileService.CheckForFileChangesAsync));
-
-                return;
+                case AzuraCastStationEntity azuraCastStation:
+                    await _azuraFileService.CheckForFileChangesAsync(azuraCastStation);
+                    return;
             }
 
-            await _azuraFileService.CheckForFileChangesAsync(azuraStation);
+            IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadPrefs: true, loadStations: true, loadStationChecks: true, loadGuild: true);
+            if (azuraCasts.Count is 0)
+                return;
+
+            stationsToCheck = azuraCasts.SelectMany(static ac => ac.Stations.Where(static s => s.Checks.FileChanges));
+            await Task.WhenAll(stationsToCheck.Select(_azuraFileService.CheckForFileChangesAsync));
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
@@ -25,19 +25,18 @@ public sealed class AzuraCheckUpdatesJob(IAzuraCastUpdateService azuraUpdateServ
 
         try
         {
-            if (context.Parameter is not AzuraCastEntity azuraCast)
+            if (context.Parameter is AzuraCastEntity azuraCast)
             {
-                IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadChecks: true, loadPrefs: true, loadGuild: true);
-                if (azuraCasts.Count is 0)
-                    return;
-
-                IEnumerable<AzuraCastEntity> azuraCastsToCheck = azuraCasts.Where(static a => a.IsOnline && a.Checks.Updates);
-                await Task.WhenAll(azuraCastsToCheck.Select(ac => _azuraUpdateService.CheckForAzuraCastUpdatesAsync(ac, forced: false)));
-
+                await _azuraUpdateService.CheckForAzuraCastUpdatesAsync(azuraCast, forced: true);
                 return;
             }
 
-            await _azuraUpdateService.CheckForAzuraCastUpdatesAsync(azuraCast, forced: true);
+            IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadChecks: true, loadPrefs: true, loadGuild: true);
+            if (azuraCasts.Count is 0)
+                return;
+
+            IEnumerable<AzuraCastEntity> azuraCastsToCheck = azuraCasts.Where(static a => a.IsOnline && a.Checks.Updates);
+            await Task.WhenAll(azuraCastsToCheck.Select(ac => _azuraUpdateService.CheckForAzuraCastUpdatesAsync(ac, forced: false)));
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraCheckUpdatesJob.cs
@@ -21,16 +21,23 @@ public sealed class AzuraCheckUpdatesJob(IAzuraCastUpdateService azuraUpdateServ
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         try
         {
-            IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadChecks: true, loadPrefs: true, loadGuild: true);
-            if (!azuraCasts.Any())
-                return;
-
-            foreach (AzuraCastEntity azuraCast in azuraCasts.Where(a => a.IsOnline && a.Checks.Updates))
+            if (context.Parameter is not AzuraCastEntity azuraCast)
             {
-                await _azuraUpdateService.CheckForAzuraCastUpdatesAsync(azuraCast);
+                IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadChecks: true, loadPrefs: true, loadGuild: true);
+                if (azuraCasts.Count is 0)
+                    return;
+
+                IEnumerable<AzuraCastEntity> azuraCastsToCheck = azuraCasts.Where(static a => a.IsOnline && a.Checks.Updates);
+                await Task.WhenAll(azuraCastsToCheck.Select(ac => _azuraUpdateService.CheckForAzuraCastUpdatesAsync(ac, forced: false)));
+
+                return;
             }
+
+            await _azuraUpdateService.CheckForAzuraCastUpdatesAsync(azuraCast, forced: true);
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
@@ -37,9 +37,14 @@ public sealed class AzuraPersistentNowPlayingJob(ILogger<AzuraPersistentNowPlayi
             if (azuraCasts.Count is 0)
                 return;
 
-            IEnumerable<AzuraCastEntity> azuraCastsToCheck = azuraCasts.Where(static a => a.IsOnline);
-            IEnumerable<AzuraCastStationEntity> stationsToCheck = azuraCastsToCheck.SelectMany(static a => a.Stations.Where(static s => s.Preferences.NowPlayingEmbedChannelId is > 0));
-            await Task.WhenAll(stationsToCheck.Select(UpdateNowPlayingEmbedAsync));
+            IEnumerable<AzuraCastStationEntity> stationsToCheck = azuraCasts.Where(static a => a.IsOnline)
+                .SelectMany(static a => a.Stations.Where(static s => s.Preferences.NowPlayingEmbedChannelId is > 0));
+
+            foreach (AzuraCastStationEntity station in stationsToCheck)
+            {
+                token.ThrowIfCancellationRequested();
+                await UpdateNowPlayingEmbedAsync(station);
+            }
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraPersistentNowPlayingJob.cs
@@ -34,16 +34,12 @@ public sealed class AzuraPersistentNowPlayingJob(ILogger<AzuraPersistentNowPlayi
         try
         {
             IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadPrefs: true, loadStations: true, loadStationPrefs: true, loadGuild: true);
-            if (!azuraCasts.Any())
+            if (azuraCasts.Count is 0)
                 return;
 
-            foreach (AzuraCastEntity azuraCast in azuraCasts.Where(static a => a.IsOnline))
-            {
-                foreach (AzuraCastStationEntity station in azuraCast.Stations.Where(static s => s.Preferences.NowPlayingEmbedChannelId is > 0))
-                {
-                    await UpdateNowPlayingEmbedAsync(station);
-                }
-            }
+            IEnumerable<AzuraCastEntity> azuraCastsToCheck = azuraCasts.Where(static a => a.IsOnline);
+            IEnumerable<AzuraCastStationEntity> stationsToCheck = azuraCastsToCheck.SelectMany(static a => a.Stations.Where(static s => s.Preferences.NowPlayingEmbedChannelId is > 0));
+            await Task.WhenAll(stationsToCheck.Select(UpdateNowPlayingEmbedAsync));
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
@@ -21,16 +21,23 @@ public sealed class AzuraStatusPingJob(IAzuraCastPingService pingService, IDbAct
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         try
         {
-            IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadChecks: true, loadPrefs: true, loadGuild: true);
-            if (!azuraCasts.Any())
-                return;
-
-            foreach (AzuraCastEntity azuraCast in azuraCasts.Where(a => a.Checks.ServerStatus))
+            if (context.Parameter is not AzuraCastEntity azuraCast)
             {
-                await _pingService.PingInstanceAsync(azuraCast);
+                IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadChecks: true, loadPrefs: true, loadGuild: true);
+                if (azuraCasts.Count is 0)
+                    return;
+
+                IEnumerable<AzuraCastEntity> azuraCastsToPing = azuraCasts.Where(static a => a.Checks.ServerStatus);
+                await Task.WhenAll(azuraCastsToPing.Select(_pingService.PingInstanceAsync));
+
+                return;
             }
+
+            await _pingService.PingInstanceAsync(azuraCast);
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzuraStatusPingJob.cs
@@ -25,19 +25,18 @@ public sealed class AzuraStatusPingJob(IAzuraCastPingService pingService, IDbAct
 
         try
         {
-            if (context.Parameter is not AzuraCastEntity azuraCast)
+            if (context.Parameter is AzuraCastEntity azuraCast)
             {
-                IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadChecks: true, loadPrefs: true, loadGuild: true);
-                if (azuraCasts.Count is 0)
-                    return;
-
-                IEnumerable<AzuraCastEntity> azuraCastsToPing = azuraCasts.Where(static a => a.Checks.ServerStatus);
-                await Task.WhenAll(azuraCastsToPing.Select(_pingService.PingInstanceAsync));
-
+                await _pingService.PingInstanceAsync(azuraCast);
                 return;
             }
 
-            await _pingService.PingInstanceAsync(azuraCast);
+            IReadOnlyList<AzuraCastEntity> azuraCasts = await _dbActions.ReadAzuraCastsAsync(loadChecks: true, loadPrefs: true, loadGuild: true);
+            if (azuraCasts.Count is 0)
+                return;
+
+            IEnumerable<AzuraCastEntity> azuraCastsToPing = azuraCasts.Where(static a => a.Checks.ServerStatus);
+            await Task.WhenAll(azuraCastsToPing.Select(_pingService.PingInstanceAsync));
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/AzzyBotCheckPermissionsJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/AzzyBotCheckPermissionsJob.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 using AzzyBot.Bot.Services.Interfaces;
+using AzzyBot.Bot.Structs;
 using AzzyBot.Data.Entities;
 using AzzyBot.Data.Services.Interfaces;
 
@@ -19,10 +19,27 @@ public sealed class AzzyBotCheckPermissionsJob(IDbActions dbActions, IDiscordBot
 
     public async Task RunAsync(IJobExecutionContext context, CancellationToken token)
     {
+        ArgumentNullException.ThrowIfNull(context);
+
         try
         {
+            if (context.Parameter is AzzyCheckPermissionsStruct permissionsStruct)
+            {
+                if (permissionsStruct.DiscordGuild is not null && permissionsStruct.DiscordGuildIds is not null)
+                {
+                    await _botService.CheckPermissionsAsync(permissionsStruct.DiscordGuild, [.. permissionsStruct.DiscordGuildIds]);
+                    return;
+                }
+
+                if (permissionsStruct.GuildEntity is not null)
+                {
+                    await _botService.CheckPermissionsAsync(permissionsStruct.GuildEntity);
+                    return;
+                }
+            }
+
             IReadOnlyList<GuildEntity> guilds = await _dbActions.ReadGuildsAsync(loadEverything: true);
-            if (!guilds.Any())
+            if (guilds.Count is 0)
                 return;
 
             await _botService.CheckPermissionsAsync(guilds);

--- a/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,7 +36,11 @@ public sealed class MusicStreamingPersistentNowPlayingJob(ILogger<MusicStreaming
             if (musicStreams.Count is 0)
                 return;
 
-            await Task.WhenAll(musicStreams.Select(UpdateNowPlayingEmbedAsync));
+            foreach (MusicStreamingEntity stream in musicStreams)
+            {
+                token.ThrowIfCancellationRequested();
+                await UpdateNowPlayingEmbedAsync(stream);
+            }
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
+++ b/src/AzzyBot.Bot/Services/CronJobs/MusicStreamingPersistentNowPlayingJob.cs
@@ -34,13 +34,10 @@ public sealed class MusicStreamingPersistentNowPlayingJob(ILogger<MusicStreaming
         try
         {
             IReadOnlyList<MusicStreamingEntity> musicStreams = await _dbActions.ReadMusicStreamingAsync(loadGuild: true);
-            if (!musicStreams.Any())
+            if (musicStreams.Count is 0)
                 return;
 
-            foreach (MusicStreamingEntity stream in musicStreams)
-            {
-                await UpdateNowPlayingEmbedAsync(stream);
-            }
+            await Task.WhenAll(musicStreams.Select(UpdateNowPlayingEmbedAsync));
         }
         catch (Exception ex) when (ex is not OperationCanceledException or TaskCanceledException)
         {

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -14,7 +14,7 @@ public interface ICronJobManager : IExceptionHandler
     void RunAzuraCheckUpdatesJob();
     void RunAzuraPersistentNowPlayingJob();
     void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem);
-    void RunAzuraStatusPingJob();
+    void RunAzuraStatusPingJob(AzuraCastEntity azuraCast);
     void RunAzzyBotCheckPermissionsJob();
     void RunAzzyBotInactiveGuildJob();
     void RunAzzyBotUpdateCheckJob();

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -1,4 +1,5 @@
 using AzzyBot.Bot.Models.AzuraCast;
+using AzzyBot.Data.Entities;
 
 using NCronJob;
 
@@ -6,7 +7,8 @@ namespace AzzyBot.Bot.Services.Interfaces;
 
 public interface ICronJobManager : IExceptionHandler
 {
-    void RunAzuraCheckApiPermissionsJob();
+    void RunAzuraCheckApiPermissionsJob(AzuraCastEntity azuraCast);
+    void RunAzuraCheckApiPermissionsJob(AzuraCastStationEntity station);
     void RunAzuraCheckFileChangesJob();
     void RunAzuraCheckUpdatesJob();
     void RunAzuraPersistentNowPlayingJob();

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -14,14 +14,9 @@ public interface ICronJobManager : IExceptionHandler
     void RunAzuraCheckFileChangesJob(AzuraCastEntity azuraCast);
     void RunAzuraCheckFileChangesJob(AzuraCastStationEntity station);
     void RunAzuraCheckUpdatesJob(AzuraCastEntity azuraCast);
-    void RunAzuraPersistentNowPlayingJob();
     void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem);
     void RunAzuraStatusPingJob(AzuraCastEntity azuraCast);
     void RunAzzyBotCheckPermissionsJob(DiscordGuild guild, ulong[] guildIds);
     void RunAzzyBotCheckPermissionsJob(GuildEntity guild);
     void RunAzzyBotInactiveGuildJob();
-    void RunAzzyBotUpdateCheckJob();
-    void RunDatabaseCleaningJob();
-    void RunLogfileCleaningJob();
-    void RunMusicStreamingPersistentNowPlayingJob();
 }

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -9,7 +9,8 @@ public interface ICronJobManager : IExceptionHandler
 {
     void RunAzuraCheckApiPermissionsJob(AzuraCastEntity azuraCast);
     void RunAzuraCheckApiPermissionsJob(AzuraCastStationEntity station);
-    void RunAzuraCheckFileChangesJob();
+    void RunAzuraCheckFileChangesJob(AzuraCastEntity azuraCast);
+    void RunAzuraCheckFileChangesJob(AzuraCastStationEntity station);
     void RunAzuraCheckUpdatesJob();
     void RunAzuraPersistentNowPlayingJob();
     void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem);

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -1,6 +1,8 @@
 using AzzyBot.Bot.Models.AzuraCast;
 using AzzyBot.Data.Entities;
 
+using DSharpPlus.Entities;
+
 using NCronJob;
 
 namespace AzzyBot.Bot.Services.Interfaces;
@@ -15,7 +17,8 @@ public interface ICronJobManager : IExceptionHandler
     void RunAzuraPersistentNowPlayingJob();
     void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem);
     void RunAzuraStatusPingJob(AzuraCastEntity azuraCast);
-    void RunAzzyBotCheckPermissionsJob();
+    void RunAzzyBotCheckPermissionsJob(DiscordGuild guild, ulong[] guildIds);
+    void RunAzzyBotCheckPermissionsJob(GuildEntity guild);
     void RunAzzyBotInactiveGuildJob();
     void RunAzzyBotUpdateCheckJob();
     void RunDatabaseCleaningJob();

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -6,6 +6,16 @@ namespace AzzyBot.Bot.Services.Interfaces;
 
 public interface ICronJobManager : IExceptionHandler
 {
-    void RunAzzyBotInactiveGuildJob();
+    void RunAzuraCheckApiPermissionsJob();
+    void RunAzuraCheckFileChangesJob();
+    void RunAzuraCheckUpdatesJob();
+    void RunAzuraPersistentNowPlayingJob();
     void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem);
+    void RunAzuraStatusPingJob();
+    void RunAzzyBotCheckPermissionsJob();
+    void RunAzzyBotInactiveGuildJob();
+    void RunAzzyBotUpdateCheckJob();
+    void RunDatabaseCleaningJob();
+    void RunLogfileCleaningJob();
+    void RunMusicStreamingPersistentNowPlayingJob();
 }

--- a/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
+++ b/src/AzzyBot.Bot/Services/Interfaces/ICronJobManager.cs
@@ -11,7 +11,7 @@ public interface ICronJobManager : IExceptionHandler
     void RunAzuraCheckApiPermissionsJob(AzuraCastStationEntity station);
     void RunAzuraCheckFileChangesJob(AzuraCastEntity azuraCast);
     void RunAzuraCheckFileChangesJob(AzuraCastStationEntity station);
-    void RunAzuraCheckUpdatesJob();
+    void RunAzuraCheckUpdatesJob(AzuraCastEntity azuraCast);
     void RunAzuraPersistentNowPlayingJob();
     void RunAzuraRequestJob(AzuraCustomQueueItemModel queueItem);
     void RunAzuraStatusPingJob(AzuraCastEntity azuraCast);

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -45,11 +45,11 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDi
     {
         ArgumentNullException.ThrowIfNull(azuraCast);
 
-        await CheckForAdminApiPermissionsAsync(azuraCast);
-        foreach (AzuraCastStationEntity station in azuraCast.Stations)
-        {
-            await CheckForStationApiPermissionsAsync(station);
-        }
+        IEnumerable<Task> tasks = azuraCast.Stations
+            .Select(CheckForStationApiPermissionsAsync)
+            .Prepend(CheckForAdminApiPermissionsAsync(azuraCast));
+
+        await Task.WhenAll(tasks);
     }
 
     public Task CheckForApiPermissionsAsync(AzuraCastStationEntity station)

--- a/src/AzzyBot.Bot/Services/UpdaterService.cs
+++ b/src/AzzyBot.Bot/Services/UpdaterService.cs
@@ -54,7 +54,10 @@ public sealed class UpdaterService(ILogger<UpdaterService> logger, IOptions<Azzy
             return;
         }
 
-        AzzyUpdateModel? updaterModel = (isPreview) ? JsonSerializer.Deserialize(body, JsonSourceGen.Default.ListAzzyUpdateModel)?[0] : JsonSerializer.Deserialize(body, JsonSourceGen.Default.AzzyUpdateModel);
+        AzzyUpdateModel? updaterModel = (isPreview)
+            ? JsonSerializer.Deserialize(body, JsonSourceGen.Default.ListAzzyUpdateModel)?[0]
+            : JsonSerializer.Deserialize(body, JsonSourceGen.Default.AzzyUpdateModel);
+
         if (updaterModel is null)
         {
             _logger.OnlineVersionUnserializable();

--- a/src/AzzyBot.Bot/Structs/AzzyCheckPermissionsStruct.cs
+++ b/src/AzzyBot.Bot/Structs/AzzyCheckPermissionsStruct.cs
@@ -20,8 +20,8 @@ public readonly struct AzzyCheckPermissionsStruct : IEquatable<AzzyCheckPermissi
 
     public bool Equals(AzzyCheckPermissionsStruct other)
         => Equals(DiscordGuild, other.DiscordGuild) &&
-            DiscordGuildIds != other.DiscordGuildIds &&
-            GuildEntity != other.GuildEntity;
+            EqualityComparer<IReadOnlyList<ulong>?>.Default.Equals(DiscordGuildIds, other.DiscordGuildIds) &&
+            Equals(GuildEntity, other.GuildEntity);
 
     public override int GetHashCode()
         => HashCode.Combine(DiscordGuild, DiscordGuildIds, GuildEntity);

--- a/src/AzzyBot.Bot/Structs/AzzyCheckPermissionsStruct.cs
+++ b/src/AzzyBot.Bot/Structs/AzzyCheckPermissionsStruct.cs
@@ -19,9 +19,9 @@ public readonly struct AzzyCheckPermissionsStruct : IEquatable<AzzyCheckPermissi
         => obj is AzzyCheckPermissionsStruct other && Equals(other);
 
     public bool Equals(AzzyCheckPermissionsStruct other)
-        => EqualityComparer<DiscordGuild?>.Default.Equals(DiscordGuild, other.DiscordGuild) &&
-            EqualityComparer<IReadOnlyList<ulong>?>.Default.Equals(DiscordGuildIds, other.DiscordGuildIds) &&
-            EqualityComparer<GuildEntity?>.Default.Equals(GuildEntity, other.GuildEntity);
+        => Equals(DiscordGuild, other.DiscordGuild) &&
+            DiscordGuildIds != other.DiscordGuildIds &&
+            GuildEntity != other.GuildEntity;
 
     public override int GetHashCode()
         => HashCode.Combine(DiscordGuild, DiscordGuildIds, GuildEntity);

--- a/src/AzzyBot.Bot/Structs/AzzyCheckPermissionsStruct.cs
+++ b/src/AzzyBot.Bot/Structs/AzzyCheckPermissionsStruct.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+using AzzyBot.Data.Entities;
+
+using DSharpPlus.Entities;
+
+namespace AzzyBot.Bot.Structs;
+
+[StructLayout(LayoutKind.Auto)]
+public readonly struct AzzyCheckPermissionsStruct : IEquatable<AzzyCheckPermissionsStruct>
+{
+    public DiscordGuild? DiscordGuild { get; init; }
+    public IReadOnlyList<ulong>? DiscordGuildIds { get; init; }
+    public GuildEntity? GuildEntity { get; init; }
+
+    public override bool Equals(object? obj)
+        => obj is AzzyCheckPermissionsStruct other && Equals(other);
+
+    public bool Equals(AzzyCheckPermissionsStruct other)
+        => EqualityComparer<DiscordGuild?>.Default.Equals(DiscordGuild, other.DiscordGuild) &&
+            EqualityComparer<IReadOnlyList<ulong>?>.Default.Equals(DiscordGuildIds, other.DiscordGuildIds) &&
+            EqualityComparer<GuildEntity?>.Default.Equals(GuildEntity, other.GuildEntity);
+
+    public override int GetHashCode()
+        => HashCode.Combine(DiscordGuild, DiscordGuildIds, GuildEntity);
+
+    public static bool operator==(in AzzyCheckPermissionsStruct left, in AzzyCheckPermissionsStruct right)
+        => left.Equals(right);
+
+    public static bool operator !=(in AzzyCheckPermissionsStruct left, in AzzyCheckPermissionsStruct right)
+        => !left.Equals(right);
+}


### PR DESCRIPTION
This pull request refactors several command and autocomplete classes to use the `ICronJobManager` for background operations instead of directly invoking service methods. The main goal is to centralize and standardize how background jobs (like pinging AzuraCast, checking for updates, and refreshing cache) are triggered.

Key changes include:

**Refactoring to Use Cron Job Manager:**

- Replaced direct calls to `IAzuraCastPingService`, `IAzuraCastFileService`, and `IAzuraCastUpdateService` in command and autocomplete classes with corresponding methods on the new `ICronJobManager` (e.g., `RunAzuraStatusPingJob`, `RunAzuraCheckFileChangesJob`, `RunAzuraCheckUpdatesJob`). This affects both the AzuraCast and Config command groups, as well as all related autocomplete providers. [[1]](diffhunk://#diff-13d7a2cddeed58259b32e33006d7922eb06010e9d046e3235e05044057f5e1b9L26-R30) [[2]](diffhunk://#diff-111acfdca8797bd871dec7156b991c745e77ccbc12a9ca6e8a61073f7e21128eL25-R29) [[3]](diffhunk://#diff-f1fdab185190ddc4d99e3b5e30e8384487a59f35ceecd5066e04533ac9ac4d80L24-R28) [[4]](diffhunk://#diff-493e3b035b778e7f634a4cef05a9277cfa25bb6ec41284b9c161a827b71b8b64L22-R26) [[5]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL48-R52) [[6]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L45-R49)

**Command Logic Updates:**

- Updated methods that previously awaited service calls to now trigger background jobs via the cron job manager and immediately respond to the user, clarifying that the operation is running asynchronously. This includes permission checks, cache refreshes, online checks, and update checks. [[1]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL170-R170) [[2]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL184-R182) [[3]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL210-R210) [[4]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL227-R227) [[5]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dR246-L250) [[6]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dR266-L270) [[7]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L159-R159) [[8]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L220-R218) [[9]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L323-R321) [[10]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L336-R334) [[11]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L406-R407) [[12]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L461-R459) [[13]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L485-R483) [[14]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L543-R541)

**Dependency Injection and Logging:**

- Updated constructor dependencies in affected classes to remove unused services and inject only `ICronJobManager` where background jobs are needed. [[1]](diffhunk://#diff-13d7a2cddeed58259b32e33006d7922eb06010e9d046e3235e05044057f5e1b9L26-R30) [[2]](diffhunk://#diff-111acfdca8797bd871dec7156b991c745e77ccbc12a9ca6e8a61073f7e21128eL25-R29) [[3]](diffhunk://#diff-f1fdab185190ddc4d99e3b5e30e8384487a59f35ceecd5066e04533ac9ac4d80L24-R28) [[4]](diffhunk://#diff-493e3b035b778e7f634a4cef05a9277cfa25bb6ec41284b9c161a827b71b8b64L22-R26) [[5]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL48-R52) [[6]](diffhunk://#diff-80c7ad7091619c3c92615cc662823d8aed0d6dcf2cb46c173fea8ade48b93f00L45-R49)
- Fixed a minor issue in `AzuraCastOnlineCheck` by ensuring the logger is properly assigned and referenced. [[1]](diffhunk://#diff-27cfac53931259a177f5779c5cdbab098a4fe51d00c110a9919694d366007b44R19) [[2]](diffhunk://#diff-27cfac53931259a177f5779c5cdbab098a4fe51d00c110a9919694d366007b44L32-R33)