### PR TITLE
Implement command to retrieve AzuraCast station logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 - A bug was fixed regarding searches in autocompletes for stations
 - An `ArgumentException` could appear when you have multiple stations using the same discord roles
+- More exceptions in the autocomplete handling are caught now
 - The `azzy help` command autocomplete works now and shows the commands even when nothing is typed in the search field
 
 ### Development

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 - Added a missing package to the docker images to fix errors regarding authentication
 - Upgraded docker images to Ubuntu 26.04 resolute
 
+### Additions
+- Added a new command `azuracast get-station-logs`
+  - This command is similar to `azuracast get-system-logs` but only shows the logs of a specific station
+
 ### Improvements
 - Re-enabled HTTP/3 support after implementing several packages in the Dockerfiles
 - The bot now also sends a welcome notification to the first channel it can see when it's added to a server

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastPlaylistAutocomplete.cs
@@ -68,7 +68,7 @@ public sealed class AzuraCastPlaylistAutocomplete(ILogger<AzuraCastPlaylistAutoc
                 return [];
             }
         }
-        catch (HttpRequestException)
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
         {
             _cronJobManager.RunAzuraStatusPingJob(station.AzuraCast);
             return [];

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationLogAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationLogAutocomplete.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -19,9 +21,9 @@ using Microsoft.Extensions.Logging;
 
 namespace AzzyBot.Bot.Commands.Autocompletes;
 
-public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAutocomplete> logger, IAzuraCastApiService azuraCastApi, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
+public sealed class AzuraCastStationLogAutocomplete(ILogger<AzuraCastStationLogAutocomplete> logger, IAzuraCastApiService azuraCastApi, ICronJobManager cronJobManager, IDbActions dbActions, IDiscordBotService botService) : IAutoCompleteProvider
 {
-    private readonly ILogger<AzuraCastSystemLogAutocomplete> _logger = logger;
+    private readonly ILogger<AzuraCastStationLogAutocomplete> _logger = logger;
     private readonly IAzuraCastApiService _azuraCastApi = azuraCastApi;
     private readonly ICronJobManager _cronJobManager = cronJobManager;
     private readonly IDbActions _dbActions = dbActions;
@@ -32,38 +34,42 @@ public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAut
         ArgumentNullException.ThrowIfNull(context);
         ArgumentNullException.ThrowIfNull(context.Guild);
 
-        AzuraCastEntity? azuraCast = await _dbActions.ReadAzuraCastAsync(context.Guild.Id);
-        if (azuraCast is null)
+        int stationId = Convert.ToInt32(context.Options.Single(static o => o.Name is "station" && o.Value is not null).Value, CultureInfo.InvariantCulture);
+        if (stationId is 0)
+            return [];
+
+        AzuraCastStationEntity? station = await _dbActions.ReadAzuraCastStationAsync(context.Guild.Id, stationId, loadAzuraCast: true, loadAzuraCastPrefs: true);
+        if (station is null)
         {
-            _logger.DatabaseAzuraCastNotFound(context.Guild.Id);
+            _logger.DatabaseAzuraCastStationNotFound(context.Guild.Id, 0, stationId);
             return [];
         }
-        else if (!azuraCast.IsOnline)
+        else if (!station.AzuraCast.IsOnline)
         {
             return [];
         }
 
-        Uri baseUrl = new(Crypto.Decrypt(azuraCast.BaseUrl));
-        string apiKey = Crypto.Decrypt(azuraCast.AdminApiKey);
-        AzuraSystemLogsModel? systemLogs;
+        Uri baseUrl = new(Crypto.Decrypt(station.AzuraCast.BaseUrl));
+        string apiKey = (string.IsNullOrEmpty(station.ApiKey)) ? Crypto.Decrypt(station.AzuraCast.AdminApiKey) : Crypto.Decrypt(station.ApiKey);
+        IEnumerable<AzuraSystemLogEntryModel>? stationLogs;
         try
         {
-            systemLogs = await _azuraCastApi.GetSystemLogsAsync(baseUrl, apiKey);
-            if (systemLogs is null)
+            stationLogs = await _azuraCastApi.GetStationLogsAsync(baseUrl, apiKey, stationId);
+            if (stationLogs is null)
             {
-                await _botService.SendMessageAsync(azuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the administrative **system logs** endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the administrative **system logs** endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return [];
             }
         }
         catch (HttpRequestException)
         {
-            _cronJobManager.RunAzuraStatusPingJob(azuraCast);
+            _cronJobManager.RunAzuraStatusPingJob(station.AzuraCast);
             return [];
         }
 
         string? search = context.UserInput;
         List<DiscordAutoCompleteChoice> results = new(25);
-        foreach (AzuraSystemLogEntryModel log in systemLogs.Logs)
+        foreach (AzuraSystemLogEntryModel log in stationLogs)
         {
             if (results.Count is 25)
                 break;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationLogAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationLogAutocomplete.cs
@@ -57,11 +57,11 @@ public sealed class AzuraCastStationLogAutocomplete(ILogger<AzuraCastStationLogA
             stationLogs = await _azuraCastApi.GetStationLogsAsync(baseUrl, apiKey, stationId);
             if (stationLogs is null)
             {
-                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the administrative **system logs** endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
+                await _botService.SendMessageAsync(station.AzuraCast.Preferences.NotificationChannelId, $"I don't have the permission to access the **station logs** endpoint.\n{_azuraCastApi.AzuraCastPermissionsWiki}");
                 return [];
             }
         }
-        catch (HttpRequestException)
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
         {
             _cronJobManager.RunAzuraStatusPingJob(station.AzuraCast);
             return [];

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsInDbAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastStationsInDbAutocomplete.cs
@@ -70,7 +70,7 @@ public sealed class AzuraCastStationsInDbAutocomplete(ILogger<AzuraCastStationsI
                     return results;
                 }
             }
-            catch (HttpRequestException)
+            catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
             {
                 _cronJobManager.RunAzuraStatusPingJob(azuraCast);
                 return results;

--- a/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
+++ b/src/AzzyBot.Bot/Commands/Autocompletes/AzuraCastSystemLogAutocomplete.cs
@@ -55,7 +55,7 @@ public sealed class AzuraCastSystemLogAutocomplete(ILogger<AzuraCastSystemLogAut
                 return [];
             }
         }
-        catch (HttpRequestException)
+        catch (Exception ex) when (ex is HttpRequestException or InvalidOperationException)
         {
             _cronJobManager.RunAzuraStatusPingJob(azuraCast);
             return [];

--- a/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
+++ b/src/AzzyBot.Bot/Commands/AzuraCastCommands.cs
@@ -299,8 +299,61 @@ public sealed class AzuraCastCommands
             string fileName = $"{ac.Id}_{logName}_{DateTimeOffset.Now:yyyy-MM-dd_hh-mm-ss-fffffff}.log";
             string filePath = await FileOperations.CreateTempFileAsync(systemLog.Content, fileName);
             await using FileStream fileStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.None);
-            DiscordMessageBuilder builder = new();
-            builder.WithContent($"Here is the requested system log ({logName}).");
+            DiscordMessageBuilder builder = new()
+            {
+                Content = $"Here is the requested system log ({logName})."
+            };
+            builder.AddFile(fileName, fileStream, AddFileOptions.CloseStream);
+            await context.EditResponseAsync(builder);
+
+            FileOperations.DeleteFile(filePath);
+        }
+
+        [Command("get-station-logs"), Description("Get the station logs of the selected station."), AzuraCastDiscordPermCheck([AzuraCastDiscordPerm.StationAdminGroup, AzuraCastDiscordPerm.InstanceAdminGroup]), AzuraCastOnlineCheck]
+        public async ValueTask GetStationLogsAsync
+        (
+            SlashCommandContext context,
+            [Description("The station of which you want to see the logs."), SlashAutoCompleteProvider<AzuraCastStationsInDbAutocomplete>] int station,
+            [Description("The station log you want to see."), SlashAutoCompleteProvider<AzuraCastStationLogAutocomplete>] string logName
+        )
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(context.Guild);
+
+            _logger.CommandRequested(nameof(GetStationLogsAsync), context.User.Username);
+
+            AzuraCastEntity? ac = await _dbActions.ReadAzuraCastAsync(context.Guild.Id, loadStations: true);
+            if (ac is null)
+            {
+                _logger.DatabaseAzuraCastNotFound(context.Guild.Id);
+                await context.EditResponseAsync(GeneralStrings.InstanceNotFound);
+                return;
+            }
+
+            AzuraCastStationEntity? acStation = ac.Stations.FirstOrDefault(s => s.StationId == station);
+            if (acStation is null)
+            {
+                _logger.DatabaseAzuraCastStationNotFound(context.Guild.Id, ac.Id, station);
+                await context.EditResponseAsync(GeneralStrings.StationNotFound);
+                return;
+            }
+
+            string apiKey = (!string.IsNullOrEmpty(acStation.ApiKey)) ? Crypto.Decrypt(acStation.ApiKey) : Crypto.Decrypt(ac.AdminApiKey);
+            Uri baseUrl = new(Crypto.Decrypt(ac.BaseUrl));
+            AzuraSystemLogModel? stationLog = await _azuraCastApi.GetStationLogAsync(baseUrl, apiKey, station, logName);
+            if (stationLog is null)
+            {
+                await context.EditResponseAsync(GeneralStrings.StationLogEmpty);
+                return;
+            }
+
+            string fileName = $"{ac.Id}-{acStation.Id}-{acStation.StationId}_{logName}_{DateTimeOffset.Now:yyyy-MM-dd_hh-mm-ss-fffffff}.log";
+            string filePath = await FileOperations.CreateTempFileAsync(stationLog.Content, fileName);
+            await using FileStream fileStream = new(filePath, FileMode.Open, FileAccess.Read, FileShare.None);
+            DiscordMessageBuilder builder = new()
+            {
+                Content = $"Here is the requested station log ({logName})."
+            };
             builder.AddFile(fileName, fileStream, AddFileOptions.CloseStream);
             await context.EditResponseAsync(builder);
 

--- a/src/AzzyBot.Bot/Helpers/GeneralStrings.cs
+++ b/src/AzzyBot.Bot/Helpers/GeneralStrings.cs
@@ -61,6 +61,7 @@ public static class GeneralStrings
     public const string SongRequestNotFound = "This song does not exist.";
     public const string SongRequestOffline = "Because local file caching is disabled, I can't request infos about songs while your instance is offline.";
     public const string SongRequestQueued = "Your song request has been queued.";
+    public const string StationLogEmpty = "This station log is empty and cannot be viewed.";
     public const string StationNotFound = "This station does not exist.";
     public const string StationOffline = "This station is currently offline.";
     public const string StationUsersDisconnected = "All users have been disconnected from the station.";

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -100,12 +100,13 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDi
         if (config is null)
             return;
 
-        List<Uri> apis = new(6)
+        List<Uri> apis = new(7)
         {
             new($"{apiUrl}/{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.History}"),
             new($"{apiUrl}/{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Playlists}"),
             new($"{apiUrl}/{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Queue}"),
-            new($"{apiUrl}/{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Status}")
+            new($"{apiUrl}/{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Status}"),
+            new($"{apiUrl}/{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Logs}")
         };
 
         if (config.EnableRequests)
@@ -573,6 +574,33 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDi
         string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Listeners}";
 
         return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraStationListenerModel, CreateHeader(apiKey));
+    }
+
+    public async Task<AzuraSystemLogModel?> GetStationLogAsync(Uri baseUrl, string apiKey, int stationId, string logName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(logName);
+
+        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Log}/{logName}";
+
+        try
+        {
+            return await GetFromApiAsync(baseUrl, endpoint, JsonSourceGen.Default.AzuraSystemLogModel, CreateHeader(apiKey));
+        }
+        catch (HttpRequestException)
+        {
+            return null;
+        }
+    }
+
+    public Task<IEnumerable<AzuraSystemLogEntryModel>?> GetStationLogsAsync(Uri baseUrl, string apiKey, int stationId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stationId);
+
+        string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Logs}";
+
+        return GetFromApiListAsync(baseUrl, endpoint, JsonSourceGen.Default.IEnumerableAzuraSystemLogEntryModel, CreateHeader(apiKey));
     }
 
     public Task<IEnumerable<AzuraHlsMountModel>?> GetStationHlsMountPointsAsync(Uri baseUrl, string apiKey, int stationId)

--- a/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/AzuraCastApiService.cs
@@ -579,6 +579,7 @@ public sealed class AzuraCastApiService(ILogger<AzuraCastApiService> logger, IDi
     public async Task<AzuraSystemLogModel?> GetStationLogAsync(Uri baseUrl, string apiKey, int stationId, string logName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(apiKey);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(stationId);
         ArgumentException.ThrowIfNullOrWhiteSpace(logName);
 
         string endpoint = $"{AzuraApiEndpoints.Station}/{stationId}/{AzuraApiEndpoints.Log}/{logName}";

--- a/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastApiService.cs
+++ b/src/AzzyBot.Bot/Services/Modules/Interfaces/IAzuraCastApiService.cs
@@ -38,6 +38,8 @@ public interface IAzuraCastApiService
     Task<IEnumerable<AzuraStationHistoryItemModel>?> GetStationHistoryAsync(Uri baseUrl, string apiKey, int stationId, in DateTimeOffset startHistory, in DateTimeOffset endHistory);
     Task<IEnumerable<AzuraHlsMountModel>?> GetStationHlsMountPointsAsync(Uri baseUrl, string apiKey, int stationId);
     Task<IEnumerable<AzuraStationListenerModel>?> GetStationListenersAsync(Uri baseUrl, string apiKey, int stationId);
+    Task<AzuraSystemLogModel?> GetStationLogAsync(Uri baseUrl, string apiKey, int stationId, string logName);
+    Task<IEnumerable<AzuraSystemLogEntryModel>?> GetStationLogsAsync(Uri baseUrl, string apiKey, int stationId);
     Task<IEnumerable<AzuraStationQueueItemDetailedModel>?> GetStationQueueAsync(Uri baseUrl, string apiKey, int stationId);
     Task<IEnumerable<AzuraRequestQueueItemModel>?> GetStationRequestItemsAsync(Uri baseUrl, string apiKey, int stationId, bool history);
     Task<AzuraSystemLogModel?> GetSystemLogAsync(Uri baseUrl, string apiKey, string logName);

--- a/src/AzzyBot.Bot/Utilities/JsonSourceGen.cs
+++ b/src/AzzyBot.Bot/Utilities/JsonSourceGen.cs
@@ -49,6 +49,7 @@ namespace AzzyBot.Bot.Utilities;
 [JsonSerializable(typeof(AzuraStatusModel))]
 [JsonSerializable(typeof(AzuraSystemLogsModel))]
 [JsonSerializable(typeof(AzuraSystemLogModel))]
+[JsonSerializable(typeof(IEnumerable<AzuraSystemLogEntryModel>))]
 [JsonSerializable(typeof(AzuraUpdateModel))]
 [JsonSerializable(typeof(AzuraUpdateErrorModel))]
 [JsonSerializable(typeof(List<AzzyUpdateModel>))]


### PR DESCRIPTION
This pull request introduces a new feature allowing users to retrieve and autocomplete station-specific logs via the `azuracast get-station-logs` command, alongside several related improvements and refactorings. The main changes include the implementation of the new command and its autocomplete provider, updates to API service interfaces and models, and minor bug fixes and enhancements to existing logging utilities.

**New Feature: Station Log Retrieval**
- Added a new command `azuracast get-station-logs` to fetch logs for a specific station, similar to the existing system logs command. This includes a new autocomplete provider for selecting station logs, and appropriate API calls and error handling. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR6-R9) [[2]](diffhunk://#diff-6918adb0be952ef0bf324f38c0fee2b6b7a12bd3e5a06cf77da9c16c8a75b63dL302-R356) [[3]](diffhunk://#diff-67bc3162a2cdceec05c4e3f2a42e5d92bcf26484125d2bc79f7ec60fc8f0fbdcR1-R85)

**API Service Enhancements**
- Extended `IAzuraCastApiService` and its implementation to support fetching a list of station logs and individual station log contents via new methods: `GetStationLogsAsync` and `GetStationLogAsync`. [[1]](diffhunk://#diff-57394c446a3102b527adec8d068a819531a5435523539e0db5212f1a4d09520bR41-R42) [[2]](diffhunk://#diff-295528a42b2ac5b52a7ea1e0101e1710afd853bdf3c14ef8cddcb0a23aad5d19R579-R605)
- Updated API permission checks to include the new logs endpoint for stations.
- Registered the new model for deserialization in `JsonSourceGen`.

**User Experience and Messaging**
- Added a new user-facing message `StationLogEmpty` for cases where a station log is empty and cannot be viewed.

**Bug Fixes and Refactoring**
- Fixed a minor issue in the system log autocomplete provider by moving the `search` variable to the correct location. [[1]](diffhunk://#diff-493e3b035b778e7f634a4cef05a9277cfa25bb6ec41284b9c161a827b71b8b64L46) [[2]](diffhunk://#diff-493e3b035b778e7f634a4cef05a9277cfa25bb6ec41284b9c161a827b71b8b64R64)

These changes collectively improve the bot's logging capabilities, making it easier for users to access and filter station-specific logs directly from Discord.